### PR TITLE
Set timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Asynchronous library to control Philips Hue
 
-Requires Python 3.5 and uses asyncio and aiohttp.
+Requires Python 3.8+ and uses asyncio and aiohttp.
 
 ```python
 import asyncio

--- a/aiohue/clip.py
+++ b/aiohue/clip.py
@@ -6,7 +6,7 @@ class Clip:
 
     async def next_events(self):
         """Note, this method will be pending until next event."""
-        return await self._request_2("get", "eventstream/clip/v2", timeout=None)
+        return await self._request_2("get", "eventstream/clip/v2", timeout=360)
 
     async def resources(self):
         """Fetch resources from Hue.

--- a/example.py
+++ b/example.py
@@ -129,7 +129,9 @@ async def run(websession):
                     sensor.name, sensor.state, sensor.config
                 )
             )
-        logger.debug("sensor %s: %s", sensor.id, pformat(sensor.state))
+        logger.debug(
+            "sensor %s (%s): %s", sensor.id, sensor.type, pformat(sensor.state)
+        )
 
     print()
     print("Listening for events")

--- a/example.py
+++ b/example.py
@@ -1,3 +1,4 @@
+from aiohue.errors import LinkButtonNotPressed
 import asyncio
 import logging
 import os
@@ -49,9 +50,15 @@ async def run(websession):
     print("Found bridge at", bridge.host)
 
     if len(sys.argv) == 1:
-        await bridge.create_user("aiophue-example")
+        try:
+            await bridge.create_user("aiophue-example")
+        except LinkButtonNotPressed:
+            print("Press the link button on the bridge before running example.py")
+            return
+
         print("Your username is", bridge.username)
-        print("Pass this to the example to control the bridge")
+        print("Now run:")
+        print(" ".join(sys.argv) + f" {bridge.username}")
         return
 
     bridge.username = sys.argv[1]


### PR DESCRIPTION
Hue hubs disconnect our event connection at second 24, next time at 54, ~6 minutes after connecting. So set timeout to 6 minutes.

Also logging the device states in the example so we can easier map it.

```
21:34:54 Event endpoint disconnected
21:34:54 Subscribing to events
21:41:24 Event endpoint disconnected
21:41:24 Subscribing to events
21:47:54 Event endpoint disconnected
21:47:54 Subscribing to events
21:54:24 Event endpoint disconnected
21:54:24 Subscribing to events
22:00:54 Event endpoint disconnected
22:00:54 Subscribing to events
22:07:24 Event endpoint disconnected
22:07:24 Subscribing to events
22:13:54 Event endpoint disconnected
22:13:54 Subscribing to events
22:20:24 Event endpoint disconnected
22:20:24 Subscribing to events
22:26:54 Event endpoint disconnected
22:26:54 Subscribing to events
22:33:25 Event endpoint disconnected
```