### PR TITLE
Ignore non-button events on switches

### DIFF
--- a/aiohue/sensors.py
+++ b/aiohue/sensors.py
@@ -426,6 +426,16 @@ class ZLLLightLevelSensor(GenericZLLSensor):
     def tholdoffset(self):
         return self.raw["config"]["tholdoffset"]
 
+    def process_update_event(self, update):
+        state = dict(self.state)
+
+        if "light" in update and update["light"]["light_level_valid"]:
+            state["lightlevel"] = update["light"]["light_level"]
+
+        state["lastupdated"] = datetime.utcnow().replace(microsecond=0).isoformat()
+
+        self.raw = {**self.raw, "state": state}
+
     async def set_config(self, on=None, tholddark=None, tholdoffset=None):
         """Change config of a ZLL LightLevel sensor."""
         data = {
@@ -457,6 +467,16 @@ class ZLLTemperatureSensor(GenericZLLSensor):
     @property
     def temperature(self):
         return self.raw["state"]["temperature"]
+
+    def process_update_event(self, update):
+        state = dict(self.state)
+
+        if "temperature" in update and update["temperature"]["temperature_valid"]:
+            state["temperature"] = update["temperature"]["temperature"]
+
+        state["lastupdated"] = datetime.utcnow().replace(microsecond=0).isoformat()
+
+        self.raw = {**self.raw, "state": state}
 
     async def set_config(self, on=None):
         """Change config of a ZLL Temperature sensor."""

--- a/aiohue/sensors.py
+++ b/aiohue/sensors.py
@@ -122,7 +122,7 @@ class GenericSensor:
             state["battery"] = update["power_state"]["battery_level"]
 
         state["lastupdated"] = datetime.utcnow().replace(microsecond=0).isoformat()
-        self.last_event = update["type"]
+        self.last_event = update
 
         self.raw = {**self.raw, "state": state}
 

--- a/aiohue/sensors.py
+++ b/aiohue/sensors.py
@@ -144,7 +144,7 @@ class GenericCLIPSensor(GenericSensor):
 class GenericZLLSensor(GenericSensor):
     @property
     def battery(self):
-        return self.raw["config"].get("battery")
+        return self.raw["state"].get("battery", self.raw["config"].get("battery"))
 
     @property
     def lastupdated(self):
@@ -181,6 +181,9 @@ class GenericSwitchSensor:
                         state["buttonevent"] = event["buttonevent"]
                         break
                 break
+
+        if "power_state" in update:
+            state["battery"] = update["power_state"]["battery_level"]
 
         state["lastupdated"] = datetime.utcnow().replace(microsecond=0).isoformat()
 
@@ -275,6 +278,9 @@ class ZLLPresenceSensor(GenericZLLSensor):
 
         if "motion" in update:
             state["presence"] = update["motion"]["motion"]
+
+        if "power_state" in update:
+            state["battery"] = update["power_state"]["battery_level"]
 
         state["lastupdated"] = datetime.utcnow().replace(microsecond=0).isoformat()
 

--- a/example.py
+++ b/example.py
@@ -48,7 +48,7 @@ def print_sensor(sensor):
     if sensor.type in [TYPE_CLIP_SWITCH, TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH]:
         print(
             "{}: [Button Event]: {} (last_event: {})".format(
-                sensor.name, sensor.buttonevent, sensor.last_event
+                sensor.name, sensor.buttonevent, sensor.last_event["type"]
             )
         )
     elif sensor.type in [TYPE_ZLL_ROTARY]:

--- a/example.py
+++ b/example.py
@@ -46,9 +46,10 @@ def print_group(group):
 
 def print_sensor(sensor):
     if sensor.type in [TYPE_CLIP_SWITCH, TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH]:
+        last_event_type = sensor.last_event["type"] if sensor.last_event else None
         print(
             "{}: [Button Event]: {} (last_event: {})".format(
-                sensor.name, sensor.buttonevent, sensor.last_event["type"]
+                sensor.name, sensor.buttonevent, last_event_type
             )
         )
     elif sensor.type in [TYPE_ZLL_ROTARY]:

--- a/example.py
+++ b/example.py
@@ -46,7 +46,11 @@ def print_group(group):
 
 def print_sensor(sensor):
     if sensor.type in [TYPE_CLIP_SWITCH, TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH]:
-        print("{}: [Button Event]: {}".format(sensor.name, sensor.buttonevent))
+        print(
+            "{}: [Button Event]: {} (last_event: {})".format(
+                sensor.name, sensor.buttonevent, sensor.last_event
+            )
+        )
     elif sensor.type in [TYPE_ZLL_ROTARY]:
         print("{}: [Rotation Event]: {}".format(sensor.name, sensor.rotaryevent))
     elif sensor.type in [TYPE_CLIP_TEMPERATURE, TYPE_ZLL_TEMPERATURE]:


### PR DESCRIPTION
This is a workaround for #63, it ignores non button events on switches.

Of course, the better approach would be to properly handle `device_power` events and update the state of the sensor.

My understanding of the API is that consumers have to compare before and after state in order to compute what changed.
That makes a lot of sense for lights, where you can then track if the light was switched or dimmed.

However, for switches we may want to be able to distinguish between button presses (which could be two consecutive events with the same button id), and other events which could be a change in battery level.

What's your opinion on this? Should we introduce a `button_event` flag that would be True only when the event was a button press?