### PR TITLE
Fix temperature event

### DIFF
--- a/aiohue/sensors.py
+++ b/aiohue/sensors.py
@@ -454,7 +454,7 @@ class ZLLTemperatureSensor(GenericZLLSensor):
         state = dict(self.state)
 
         if "temperature" in update and update["temperature"]["temperature_valid"]:
-            state["temperature"] = update["temperature"]["temperature"]
+            state["temperature"] = int(update["temperature"]["temperature"] * 100)
 
         self.generic_process_update_event(update, state)
 


### PR DESCRIPTION
Temperature events come in with "normal" values while the fetched state is * 100. 

CC @jbouwh can you help test this? 