### PR TITLE
Guard for unexpected ID v1

### DIFF
--- a/aiohue/bridge.py
+++ b/aiohue/bridge.py
@@ -209,7 +209,10 @@ class Bridge:
                 if event_data.get("id_v1") in (None, "/groups/0"):
                     continue
 
-                item_type = event_data["id_v1"].split("/", 2)[1]
+                if len(id_parts := event_data["id_v1"].split("/", 2)) < 2:
+                    continue
+
+                item_type = id_parts[1]
 
                 if item_type not in (
                     # These all inherit from APIItems and so can handle events


### PR DESCRIPTION
Guard for `id_v1` that have no `/`

```
2021-10-04 21:05:57 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/home/paulus/dev/hass/core/homeassistant/components/hue/bridge.py", line 249, in _subscribe_events
    async for updated_object in self.api.listen_events():
  File "/home/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohue/bridge.py", line 212, in listen_events
    item_type = event_data["id_v1"].split("/", 2)[1]
IndexError: list index out of range
```