### PR TITLE
Parse correct mac address

### DIFF
--- a/aiohue/util.py
+++ b/aiohue/util.py
@@ -189,3 +189,17 @@ def dataclass_from_dict(cls: dataclass, dict_obj: dict, strict=False):
             for field in fields(cls)
         }
     )
+
+
+def mac_from_bridge_id(bridge_id: str) -> str:
+    """Parse mac address from bridge id."""
+    parts = [
+        bridge_id[0:2],
+        bridge_id[2:4],
+        bridge_id[4:6],
+        # part 6:10 needs to be left out (fffe)
+        bridge_id[10:12],
+        bridge_id[12:14],
+        bridge_id[14:16],
+    ]
+    return ":".join(parts)

--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Type, Union
 
-from aiohue.v2.models.bridge_home import BridgeHome
-from aiohue.v2.models.device import Device
-from aiohue.v2.models.entertainment import Entertainment, EntertainmentConfiguration
-
+from ...util import mac_from_bridge_id
 from ..models.bridge import Bridge
+from ..models.bridge_home import BridgeHome
+from ..models.device import Device
+from ..models.entertainment import Entertainment, EntertainmentConfiguration
 from ..models.resource import ResourceTypes
 from .base import BaseResourcesController, GroupedControllerBase
 
@@ -72,13 +72,8 @@ class ConfigController(
     @property
     def mac_address(self) -> str:
         """Return mac address of bridge we're connected to."""
-        return next(
-            (
-                self._bridge.sensors.zigbee_connectivity[service.rid].mac_address
-                for service in self.bridge_device.services
-                if service.rtype == ResourceTypes.ZIGBEE_CONNECTIVITY
-            )
-        )
+        # the network mac is not available in api so we parse it from the id
+        return mac_from_bridge_id(self.bridge_id)
 
     @property
     def model_id(self) -> str:


### PR DESCRIPTION
The network mac address is no longer provided in the api.
The current code returns the zigbee mac address of the bridge which is incorrect.

As the bridge_id is created from the network mac address, added a small helper to parse the network mac from the bridge id.