### PR TITLE
Add fallback for unparseable value that is optional

### DIFF
--- a/aiohue/util.py
+++ b/aiohue/util.py
@@ -162,10 +162,15 @@ def dataclass_from_dict(cls: dataclass, dict_obj: dict, strict=False):
                     return _get_val(name, value, sub_arg_type)
                 except (KeyError, TypeError, ValueError):
                     pass
-            raise TypeError(
-                f"Value {value} of type {type(value)} is invalid for {name}, "
-                f"expected value of type {value_type}"
-            )
+            # if we get to this point, all possibilities failed
+            # find out if we should raise or log this
+            err = (f"Value {value} of type {type(value)} is invalid for {name}, "
+                  f"expected value of type {value_type}")
+            if NoneType not in sub_value_types:
+                # raise exception, we have no idea how to handle this value   
+                raise TypeError(err)
+            # failed to parse the (sub) value but None allowed, log only
+            logging.getLogger(__name__).warn(err)
         if value_type is Any:
             return value
         if value is None and value_type is not NoneType:

--- a/aiohue/util.py
+++ b/aiohue/util.py
@@ -164,13 +164,16 @@ def dataclass_from_dict(cls: dataclass, dict_obj: dict, strict=False):
                     pass
             # if we get to this point, all possibilities failed
             # find out if we should raise or log this
-            err = (f"Value {value} of type {type(value)} is invalid for {name}, "
-                  f"expected value of type {value_type}")
+            err = (
+                f"Value {value} of type {type(value)} is invalid for {name}, "
+                f"expected value of type {value_type}"
+            )
             if NoneType not in sub_value_types:
-                # raise exception, we have no idea how to handle this value   
+                # raise exception, we have no idea how to handle this value
                 raise TypeError(err)
             # failed to parse the (sub) value but None allowed, log only
             logging.getLogger(__name__).warn(err)
+            return None
         if value_type is Any:
             return value
         if value is None and value_type is not NoneType:

--- a/aiohue/v2/controllers/lights.py
+++ b/aiohue/v2/controllers/lights.py
@@ -74,7 +74,7 @@ class LightsController(BaseResourcesController[Type[Light]]):
         if transition_time is not None:
             if transition_time < 100:
                 raise AiohueException(
-                    "Transition needs to be specified in millisecond. Min 100, max 60000"
+                    "Transition needs to be specified in millisecond. Min 100, max 6000000"
                 )
             update_obj.dynamics = DynamicsFeature(duration=transition_time)
         await self._send_put(id, update_obj)


### PR DESCRIPTION
Minor fix in the parser that converts the raw data into the dataclasses from model.
When the parser is unable to parse an incoming value it will raise an exception.
If the value is however defined as optional in the model, it will now log the error only and treat the value as None.

fixes https://github.com/home-assistant/core/issues/61529

Although the xy value should be required in the "colorfeature" object according to the documentation, we've got a report where it wasn't. Third party bulb not behaving according to specs maybe ?

Anyways, this will workaround that without breaking anything downstream.