### PR TITLE
Remove check for valid transition time

### DIFF
--- a/aiohue/v2/controllers/lights.py
+++ b/aiohue/v2/controllers/lights.py
@@ -16,7 +16,6 @@ from ..models.feature import (
 from ..models.light import Light
 from ..models.resource import ResourceTypes
 from .base import BaseResourcesController
-from ...errors import AiohueException
 
 
 class LightsController(BaseResourcesController[Type[Light]]):

--- a/aiohue/v2/controllers/lights.py
+++ b/aiohue/v2/controllers/lights.py
@@ -75,10 +75,6 @@ class LightsController(BaseResourcesController[Type[Light]]):
         if color_temp is not None:
             update_obj.color_temperature = ColorTemperatureFeature(mirek=color_temp)
         if transition_time is not None:
-            if transition_time < 100:
-                raise AiohueException(
-                    "Transition needs to be specified in millisecond. Min 100, max 6000000"
-                )
             update_obj.dynamics = DynamicsFeature(duration=transition_time)
         if alert is not None:
             update_obj.alert = AlertFeature(action=alert)


### PR DESCRIPTION
Remove check for valid transition time as it is already checked by the bridge itself.
If you send a value that is out of range, the bridge will throw an error.

In fact you can actually send value 0 to turn off the transition time.

fixes https://github.com/home-assistant/core/issues/61631