### PR TITLE
Fix typo in class name

### DIFF
--- a/aiohue/v2/models/button.py
+++ b/aiohue/v2/models/button.py
@@ -29,11 +29,11 @@ class ButtonEvent(Enum):
 
 
 @dataclass
-class ButtOnFeature:
+class ButtonFeature:
     """
     Represent ButtonFeature object as used by the Hue api.
 
-    clip-api.schema.json#/definitions/ButtOnFeature
+    clip-api.schema.json#/definitions/ButtonFeature
     """
 
     last_event: ButtonEvent
@@ -64,5 +64,5 @@ class Button(Resource):
     """
 
     metadata: Optional[SwitchInputMetadata] = None
-    button: Optional[ButtOnFeature] = None
+    button: Optional[ButtonFeature] = None
     type: ResourceTypes = ResourceTypes.BUTTON

--- a/docs/clip-api.schema.json
+++ b/docs/clip-api.schema.json
@@ -268,7 +268,7 @@
         ],
         "type": "string"
       },
-      "ButtOnFeature": {
+      "ButtonFeature": {
         "type": "object",
         "properties": {
           "last_event": {
@@ -296,7 +296,7 @@
                 "$ref": "#/definitions/SwitchInputMetadata"
               },
               "button": {
-                "$ref": "#/definitions/ButtOnFeature"
+                "$ref": "#/definitions/ButtonFeature"
               }
             },
             "required": [


### PR DESCRIPTION
I was looking around the code for the first time and noticed this class name that looks like a typo: "ButtOnFeature" instead of "ButtonFeature".