### PR TITLE
Fix connection logic with timeout guard

### DIFF
--- a/aiohue/v2/__init__.py
+++ b/aiohue/v2/__init__.py
@@ -175,6 +175,7 @@ class HueBridgeV2:
             kwargs["headers"] = {}
 
         kwargs["headers"]["hue-application-key"] = self._app_key
+        kwargs["headers"]["Connection"] = "keep alive"
 
         async with self._websession.request(method, url, **kwargs) as res:
             if res.status == 403:

--- a/aiohue/v2/controllers/events.py
+++ b/aiohue/v2/controllers/events.py
@@ -166,7 +166,7 @@ class EventStream:
                     raise InvalidAPIVersion from err
                 if status == 403:
                     raise Unauthorized from err
-                elif status:
+                if status:
                     # for debugging purpose only
                     self._logger.debug(err)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp
+async-timeout


### PR DESCRIPTION
- Prevent deadlocking of SSE connection with timeout on connection and receiving of events
- Use timeout 0 on aiohttp request itself to prevent it from disconnecting the stream
- Send full state events when the connection is reconnected
- Use connection:close on SSE endpoint to prevent 503 server error

Tested this very well under different conditions and this time it holds up.

Deadlock timeout is 60 minutes, meaning that if there's not a single event received within an hour, the connection will be recreated.

This fixes https://github.com/home-assistant/core/issues/61926

yeah, this time for real ;-)