### PR TITLE
Change reconnect logic (again)

### DIFF
--- a/aiohue/v2/__init__.py
+++ b/aiohue/v2/__init__.py
@@ -179,7 +179,7 @@ class HueBridgeV2:
                 if res.status == 503:
                     # 503 means the bridge is rate limiting, we should back off a bit.
                     retries += 1
-                    await asyncio.sleep(0.5*retries)
+                    await asyncio.sleep(0.5 * retries)
                     continue
                 res.raise_for_status()
                 yield res

--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -53,9 +53,11 @@ class BaseResourcesController(Generic[CLIPResource]):
             endpoint = f"clip/v2/resource/{self.item_type.value}"
             initial_data = await self._bridge.request("get", endpoint)
         else:
-            initial_data = [x for x in initial_data if x["type"] == self.item_type.value]
+            initial_data = [
+                x for x in initial_data if x["type"] == self.item_type.value
+            ]
         self._logger.debug("fetched %s items", len(initial_data))
-        
+
         if self._initialized:
             # we're already initialized, treat this as reconnect
             await self.__handle_reconnect(initial_data)

--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -206,13 +206,13 @@ class BaseResourcesController(Generic[CLIPResource]):
             cur_ids.add(resource.id)
             if resource.id not in prev_ids:
                 # item added
-                self._handle_event(EventType.RESOURCE_ADDED, resource)
+                await self._handle_event(EventType.RESOURCE_ADDED, resource)
             else:
                 # work out if the item actually changed
                 prev_item = self._items[resource.id]
                 if dataclass_to_dict(prev_item) == dataclass_to_dict(resource):
                     continue
-                self._handle_event(EventType.RESOURCE_UPDATED, resource)
+                await self._handle_event(EventType.RESOURCE_UPDATED, resource)
         # work out item deletions
         deleted_ids = {x for x in prev_ids if x not in cur_ids}
         for resource_id in deleted_ids:

--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -58,7 +58,7 @@ class BaseResourcesController(Generic[CLIPResource]):
         
         if self._initialized:
             # we're already initialized, treat this as reconnect
-            self.__handle_reconnect(initial_data)
+            await self.__handle_reconnect(initial_data)
             return
 
         for item in initial_data:

--- a/aiohue/v2/controllers/events.py
+++ b/aiohue/v2/controllers/events.py
@@ -7,16 +7,15 @@ from asyncio.coroutines import iscoroutinefunction
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, List, NoReturn, Tuple
 
-from aiohttp.client_exceptions import ClientError
 from aiohttp import ClientTimeout
-from async_timeout import timeout
+from aiohttp.client_exceptions import ClientError
 
 if TYPE_CHECKING:
     from .. import HueBridgeV2
 
 from ...errors import InvalidAPIVersion, InvalidEvent, Unauthorized
 from ...util import NoneType
-from ..models.clip import CLIPEvent, CLIPEventType, CLIPResource, parse_clip_resource
+from ..models.clip import CLIPEvent, CLIPEventType, CLIPResource
 from ..models.resource import ResourceTypes
 
 CONNECTION_TIMEOUT = 30 * 60  # 30 minutes
@@ -161,7 +160,7 @@ class EventStream:
                 async with self._bridge.create_request(
                     "get",
                     "eventstream/clip/v2",
-                    timeout=ClientTimeout(total=0, sock_read=2),
+                    timeout=ClientTimeout(total=0, sock_read=CONNECTION_TIMEOUT),
                     headers=headers,
                 ) as resp:
                     # update status to connected once we reach this point

--- a/aiohue/v2/controllers/events.py
+++ b/aiohue/v2/controllers/events.py
@@ -161,7 +161,7 @@ class EventStream:
                 async with self._bridge.create_request(
                     "get",
                     "eventstream/clip/v2",
-                    timeout=ClientTimeout(total=0, sock_read=CONNECTION_TIMEOUT),
+                    timeout=ClientTimeout(total=0, sock_read=2),
                     headers=headers,
                 ) as resp:
                     # update status to connected once we reach this point

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 aiohttp
-async-timeout


### PR DESCRIPTION
- Emit events with connection state so consumers can act on it
- refresh state in controllers based on connection event
- Use aiohttp socket read timeout to detect stopped stream
- Guard 503 errors