### PR TITLE
Add Keep alive workaround

### DIFF
--- a/aiohue/v2/controllers/events.py
+++ b/aiohue/v2/controllers/events.py
@@ -11,7 +11,7 @@ from aiohttp import ClientTimeout
 from aiohttp.client_exceptions import ClientError
 import random
 import string
-from aiohue.v2.models.geofence_client import GeofenceClient, GeofenceClientCreate
+from aiohue.v2.models.geofence_client import GeofenceClientCreate
 
 if TYPE_CHECKING:
     from .. import HueBridgeV2

--- a/aiohue/v2/models/geofence_client.py
+++ b/aiohue/v2/models/geofence_client.py
@@ -11,8 +11,20 @@ class GeofenceClient(Resource):
     Representation of Geofence Client.
 
     clip-api.schema.json#/definitions/GeofenceClientGet
-    clip-api.schema.json#/definitions/GeofenceClientPost
     clip-api.schema.json#/definitions/GeofenceClientPut
+    """
+
+    is_at_home: Optional[bool] = None  # Indicator if Geofence Client is at home.
+    name: Optional[str] = None
+    type: ResourceTypes = ResourceTypes.GEOFENCE_CLIENT
+
+
+@dataclass
+class GeofenceClientCreate:
+    """
+    Representation of Geofence Client.
+
+    clip-api.schema.json#/definitions/GeofenceClientPost
     """
 
     is_at_home: Optional[bool] = None  # Indicator if Geofence Client is at home.


### PR DESCRIPTION
Get ready for some real funky stuff here...

This adds support for a keepalive by abusing the geofence_client resource to set a unique name every interval, which in turn results in an event on the eventstream. 

As far as I can see this causes no side effects but we might want to feature-toggle it with an environmental variable or something (if we even consider adding this).