### PR TITLE
Fix reconnect last event id

### DIFF
--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from asyncio.coroutines import iscoroutinefunction
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Generic, Iterator,
-                    List, Tuple)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Iterator, List, Tuple
 
 from aiohue.v2.models.device import Device
 

--- a/aiohue/v2/controllers/events.py
+++ b/aiohue/v2/controllers/events.py
@@ -159,6 +159,8 @@ class EventStream:
 
         while True:
             connect_attempts += 1
+            if self._last_event_id:
+                headers["last-event-id"] = self._last_event_id
             # Messages come in line by line, according to EventStream/SSE specs
             # we iterate over the incoming lines in the streamreader.
             try:
@@ -233,7 +235,7 @@ class EventStream:
             if not key:
                 return
             if key == "id":
-                self._last_event_id = value.replace(":0", "")
+                self._last_event_id = value
                 return
             if key == "data":
                 # events is array with multiple events


### PR DESCRIPTION
Turns out that Last-Event-ID does actually work on the V2 API. Key was not stripping of the colons.
This change will make sure to just rely on the SSE "last-event-id" logic so any missed events will be received at reconnect.
If the reconnect took more than 1 minute, we fallback to a full state fetch just to be safe.

Button events are filtered out when a new state is retrieved, to fix the issue with "ghost events" for Hue Tap remotes reported by people when a reconnect was happening.