### PR TITLE
Switch to limit per host on tcp connector

### DIFF
--- a/aiohue/v2/__init__.py
+++ b/aiohue/v2/__init__.py
@@ -10,7 +10,6 @@ from typing import Callable, Generator, List, Optional, Type
 
 import aiohttp
 from aiohttp import ClientResponse
-from aiohue.v2.models.clip import LOGGER, CLIPResource
 
 from ..errors import BridgeBusy, Unauthorized, raise_from_error
 from .controllers.config import ConfigController
@@ -20,6 +19,7 @@ from .controllers.groups import GroupsController
 from .controllers.lights import LightsController
 from .controllers.scenes import ScenesController
 from .controllers.sensors import SensorsController
+from .models.clip import LOGGER, CLIPResource
 
 MAX_RETRIES = 25  # how many times do we retry on a 503 (bridge overload/rate limit)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 aiohttp
-asyncio-throttle

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ MIN_PY_VERSION = "3.8"
 
 setup(
     name="aiohue",
-    version="3.0.11",
+    version="4.0.0",
     license="Apache License 2.0",
     url="https://github.com/home-assistant-libs/aiohue",
     author="Paulus Schoutsen",


### PR DESCRIPTION
According to Signify support it is very important that we have a guard in place to make sure that there are no more than 3 concurrent requests to the bridge. Putting this guard on the TCP Connector for aiohttp solves all 503 errors.

Sending 100 requests now completes in 2,2 seconds without a single 503 error ;-)

I've put a small detection in the code if a TCP connector is given without this limit (e.g. Home Assistant as a temporary measure until we can adjust the global logic in HA to respect this host limit. 