### PR TITLE
Put back asyncio-throttle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp
+asyncio-throttle


### PR DESCRIPTION
We removed `asyncio-throttle` from requirements in #104 but it was still in use for v1 API.