### PR TITLE
Allow motion sensor state to be null/none when sensor is disabled

### DIFF
--- a/aiohue/v2/models/motion.py
+++ b/aiohue/v2/models/motion.py
@@ -17,7 +17,7 @@ class MotionSensingFeature:
     https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_motion_get
     """
 
-    motion: bool
+    motion: Optional[bool] # value is None/null when sensor is disabled!
     motion_valid: bool
 
 


### PR DESCRIPTION
This is actually an error in the Hue api (or documentation) but we have to workaround it.
When a Hue motion server is disabled, its sensor value is no longer a boolean value but null in the api response.

I've reported this issue to Signify and this PR workarounds the issue by allowing a None value on the motion attribute.

fixes https://github.com/home-assistant/core/issues/66636