### PR TITLE
Small follow up fix in event logic

### DIFF
--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -222,7 +222,7 @@ class BaseResourcesController(Generic[CLIPResource]):
             # in fact this is a feature request to Signify to handle these stateless
             # device events in a different way:
             # https://developers.meethue.com/forum/t/differentiate-stateless-events/6627
-            if self.item_type != ResourceTypes.BUTTON and not evt_data.get("button"):
+            if self.item_type == ResourceTypes.BUTTON and not evt_data.get("button"):
                 return
         else:
             # ignore all other events

--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -11,7 +11,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Set,
     Tuple,
     TypeVar,
     Union,


### PR DESCRIPTION
- Adjust the reconnect logic to the recent model changes.
- Prevent state update events emitted to subscribers when nothing changed.
- Try to prevent false positive button events when the bridge is restarting or updating or the connection reestablished.

This (partially) fixes https://github.com/home-assistant/core/issues/65122