### PR TITLE
Fix float int conversion

### DIFF
--- a/aiohue/util.py
+++ b/aiohue/util.py
@@ -135,7 +135,7 @@ def parse_utc_timestamp(datetimestr: str):
 
 
 def _parse_value(name: str, value: Any, value_type: Type, default: Any = MISSING):
-    """Try to parse a value from raw data and type definitions."""
+    """Try to parse a value from raw (json) data and type definitions."""
     if value is None and not isinstance(default, type(MISSING)):
         return default
     if value is None and value_type is NoneType:
@@ -180,12 +180,14 @@ def _parse_value(name: str, value: Any, value_type: Type, default: Any = MISSING
         return value_type(value)
     if value_type is type(datetime):
         return parse_utc_timestamp(value)
+    if value_type is float and isinstance(value, int):
+        value = float(value)
     if not isinstance(value, value_type):
         raise TypeError(
             f"Value {value} of type {type(value)} is invalid for {name}, "
             f"expected value of type {value_type}"
         )
-    return value_type(value)
+    return value
 
 
 def dataclass_from_dict(cls: dataclass, dict_obj: dict, strict=False):
@@ -199,7 +201,8 @@ def dataclass_from_dict(cls: dataclass, dict_obj: dict, strict=False):
         extra_keys = dict_obj.keys() - set([f.name for f in fields(cls)])
         if extra_keys:
             raise KeyError(
-                "Extra key(s) %s not allowed for %s" % ",".join(extra_keys), (str(cls))
+                "Extra key(s) %s not allowed for %s"
+                % (",".join(extra_keys), (str(cls)))
             )
 
     return cls(

--- a/tests/v2/test_parser.py
+++ b/tests/v2/test_parser.py
@@ -1,0 +1,70 @@
+"""Test parser functions that converts the incoming json from API into dataclass models."""
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+from aiohue.util import dataclass_from_dict
+
+
+@dataclass
+class BasicModelChild:
+    """Basic test model."""
+
+    a: int
+    b: str
+    c: str
+    d: Optional[int]
+
+
+@dataclass
+class BasicModel:
+    """Basic test model."""
+
+    a: int
+    b: float
+    c: str
+    d: Optional[int]
+    e: BasicModelChild
+    f: str = "default"
+
+
+def test_dataclass_from_dict():
+    """Test dataclass from dict parsing."""
+    raw = {
+        "a": 1,
+        "b": 1.0,
+        "c": "hello",
+        "d": 1,
+        "e": {"a": 2, "b": "test", "c": "test", "d": None},
+    }
+    res = dataclass_from_dict(BasicModel, raw)
+    # test the basic values
+    assert isinstance(res, BasicModel)
+    assert res.a == 1
+    assert res.b == 1.0
+    assert res.d == 1
+    # test recursive parsing
+    assert isinstance(res.e, BasicModelChild)
+    # test default value
+    assert res.f == "default"
+    # test int gets converted to float
+    raw["b"] = 2
+    res = dataclass_from_dict(BasicModel, raw)
+    assert res.b == 2.0
+    # test string doesn't match int
+    with pytest.raises(TypeError):
+        raw2 = {**raw}
+        raw2["a"] = "blah"
+        dataclass_from_dict(BasicModel, raw2)
+    # test missing key result in keyerror
+    with pytest.raises(KeyError):
+        raw2 = {**raw}
+        del raw2["a"]
+        dataclass_from_dict(BasicModel, raw2)
+    # test extra keys silently ignored in non-strict mode
+    raw2 = {**raw}
+    raw2["extrakey"] = "something"
+    dataclass_from_dict(BasicModel, raw2, strict=False)
+    # test extra keys not silently ignored in strict mode
+    with pytest.raises(KeyError):
+        dataclass_from_dict(BasicModel, raw2, strict=True)


### PR DESCRIPTION
Another edgecase in parsing the json into our (dataclass) models.
If a float value is exactly one, it is sent as 1 (int) in the API, causing a schema mismatch.

Added a small fix for this situation by allowing an int value to be converted to float.

Also added some basic tests for the parser logic.

Fixes #116 