### PR TITLE
Loosen up a bit on parser errors

### DIFF
--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -40,6 +40,7 @@ class EntertainmentController(BaseResourcesController[Type[Entertainment]]):
 
     item_type = ResourceTypes.ENTERTAINMENT
     item_cls = Entertainment
+    allow_parser_error = True
 
 
 class EntertainmentConfigurationController(
@@ -49,6 +50,7 @@ class EntertainmentConfigurationController(
 
     item_type = ResourceTypes.ENTERTAINMENT_CONFIGURATION
     item_cls = EntertainmentConfiguration
+    allow_parser_error = True
 
 
 class ConfigController(

--- a/aiohue/v2/controllers/groups.py
+++ b/aiohue/v2/controllers/groups.py
@@ -19,6 +19,7 @@ class RoomController(BaseResourcesController[Type[Room]]):
 
     item_type = ResourceTypes.ROOM
     item_cls = Room
+    allow_parser_error = True
 
     def get_scenes(self, id: str) -> List[Scene]:
         """Get all scenes for this room."""
@@ -30,6 +31,7 @@ class ZoneController(BaseResourcesController[Type[Zone]]):
 
     item_type = ResourceTypes.ZONE
     item_cls = Zone
+    allow_parser_error = True
 
     def get_scenes(self, id: str) -> List[Scene]:
         """Get all scenes for this zone."""

--- a/aiohue/v2/controllers/scenes.py
+++ b/aiohue/v2/controllers/scenes.py
@@ -14,6 +14,7 @@ class ScenesController(BaseResourcesController[Type[Scene]]):
 
     item_type = ResourceTypes.SCENE
     item_cls = Scene
+    allow_parser_error = True
 
     async def recall(
         self,

--- a/aiohue/v2/controllers/sensors.py
+++ b/aiohue/v2/controllers/sensors.py
@@ -34,6 +34,7 @@ class DevicePowerController(BaseResourcesController[Type[DevicePower]]):
 
     item_type = ResourceTypes.DEVICE_POWER
     item_cls = DevicePower
+    allow_parser_error = True
 
 
 class ButtonController(BaseResourcesController[Type[Button]]):
@@ -41,6 +42,7 @@ class ButtonController(BaseResourcesController[Type[Button]]):
 
     item_type = ResourceTypes.BUTTON
     item_cls = Button
+    allow_parser_error = True
 
     _workaround_tasks: Dict[str, asyncio.Task] = None
 
@@ -112,6 +114,7 @@ class GeofenceClientController(BaseResourcesController[Type[GeofenceClient]]):
 
     item_type = ResourceTypes.GEOFENCE_CLIENT
     item_cls = GeofenceClient
+    allow_parser_error = True
 
 
 class LightLevelController(BaseResourcesController[Type[LightLevel]]):
@@ -119,6 +122,7 @@ class LightLevelController(BaseResourcesController[Type[LightLevel]]):
 
     item_type = ResourceTypes.LIGHT_LEVEL
     item_cls = LightLevel
+    allow_parser_error = True
 
     async def set_enabled(self, id: str, enabled: bool) -> None:
         """Enable/Disable sensor."""
@@ -130,6 +134,7 @@ class MotionController(BaseResourcesController[Type[Motion]]):
 
     item_type = ResourceTypes.MOTION
     item_cls = Motion
+    allow_parser_error = True
 
     async def set_enabled(self, id: str, enabled: bool) -> None:
         """Enable/Disable sensor."""
@@ -141,6 +146,7 @@ class TemperatureController(BaseResourcesController[Type[Temperature]]):
 
     item_type = ResourceTypes.TEMPERATURE
     item_cls = Temperature
+    allow_parser_error = True
 
 
 class ZigbeeConnectivityController(BaseResourcesController[Type[ZigbeeConnectivity]]):
@@ -148,6 +154,7 @@ class ZigbeeConnectivityController(BaseResourcesController[Type[ZigbeeConnectivi
 
     item_type = ResourceTypes.ZIGBEE_CONNECTIVITY
     item_cls = ZigbeeConnectivity
+    allow_parser_error = True
 
 
 class SensorsController(GroupedControllerBase[SENSOR_TYPES]):


### PR DESCRIPTION
In an attempt to not completely crash when a single resource can't be parsed due to API schema mismatches, bugs in Hue or other factors, we allow some resources to be skipped. 

This only works for resources that are not dependees for other resources so we define this in the controller level.