### PR TITLE
Fix changes in group (room/zone) models

### DIFF
--- a/aiohue/v2/controllers/groups.py
+++ b/aiohue/v2/controllers/groups.py
@@ -31,10 +31,12 @@ class RoomController(BaseResourcesController[Type[Room]]):
             return []
         result = []
         for dev_id in self._items[id].devices:
-            if dev := self._bridge.devices.get(dev_id):
-                for light_id in dev.lights:
-                    if light := self._bridge.lights.get(light_id):
-                        result.append(light)
+            if (dev := self._bridge.devices.get(dev_id)) is None:
+                continue
+
+            for light_id in dev.lights:
+                if light := self._bridge.lights.get(light_id):
+                    result.append(light)
         return result
 
 

--- a/aiohue/v2/controllers/groups.py
+++ b/aiohue/v2/controllers/groups.py
@@ -25,6 +25,18 @@ class RoomController(BaseResourcesController[Type[Room]]):
         """Get all scenes for this room."""
         return [scene for scene in self._bridge.scenes if scene.group.rid == id]
 
+    def get_lights(self, id: str) -> List[Light]:
+        """Return all lights in given room."""
+        if id not in self._items:
+            return []
+        result = []
+        for dev_id in self._items[id].devices:
+            if dev := self._bridge.devices.get(dev_id):
+                for light_id in dev.lights:
+                    if light := self._bridge.lights.get(light_id):
+                        result.append(light)
+        return result
+
 
 class ZoneController(BaseResourcesController[Type[Zone]]):
     """Controller holding and managing HUE resources of type `zone`."""
@@ -34,8 +46,17 @@ class ZoneController(BaseResourcesController[Type[Zone]]):
     allow_parser_error = True
 
     def get_scenes(self, id: str) -> List[Scene]:
-        """Get all scenes for this zone."""
+        """Get all scenes for this room."""
         return [scene for scene in self._bridge.scenes if scene.group.rid == id]
+
+    def get_lights(self, id: str) -> List[Light]:
+        """Return all lights in given zone."""
+        if id not in self._items:
+            return []
+        light_ids = {
+            x.rid for x in self._items[id].children if x.rtype == ResourceTypes.LIGHT
+        }
+        return [x for x in self._bridge.lights if x.id in light_ids]
 
 
 class GroupedLightController(BaseResourcesController[Type[GroupedLight]]):
@@ -54,10 +75,13 @@ class GroupedLightController(BaseResourcesController[Type[GroupedLight]]):
         return None
 
     def get_lights(self, id: str) -> List[Light]:
-        """Return all underlying lights of this grouped light."""
+        """Return lights of the connected room/zone."""
+        # Note that this is just a convenience method for backwards compatibility
         if zone := self.get_zone(id):
-            return [x for x in self._bridge.lights if x.id in zone.lights]
-        return []  # fallback for a group without a zone (special 0 group)
+            if zone.type == ResourceTypes.ROOM:
+                return self._bridge.groups.room.get_lights(zone.id)
+            return self._bridge.groups.zone.get_lights(zone.id)
+        return []
 
     async def set_state(self, id: str, on: bool = True) -> None:
         """

--- a/aiohue/v2/models/room.py
+++ b/aiohue/v2/models/room.py
@@ -113,11 +113,6 @@ class Room:
         return {x.rid for x in self.children}
 
     @property
-    def lights(self) -> Set[str]:
-        """Return a set of light id's belonging to this zone."""
-        return {x.rid for x in self.services if x.rtype == ResourceTypes.LIGHT}
-
-    @property
     def grouped_light(self) -> Optional[str]:
         """Return the grouped light id that is connected to this room (if any)."""
         if not self.services:


### PR DESCRIPTION
While fixing all API schemas to the ones reported in the (now released) API docs I missed a small spot according to how lights are grouped within a zone/room impacting the way how to retrieve lights within a room/zone. While the old way still works in non-beta Hue firmwares, getting the lights for a room needs to be done by looking at the devices in the group.

Changed the logic a bit so we can retrieve the lights for a zone/room which works on current Hue firmware (1.49) and beta firmware (1.50).

Signify is preparing a change to the rooms/zones/grouped_light schemas, allowing us to send light commands to a grouped_light directly instead of sending each command to all individual lights.
Great news as this was a feature request we did ourselves.

I've not yet implemented this change because we did not yet receive confirmation about the feature being ready so the changed responses in beta firmware is some preparation I guess. With this fix we can still address grouped lights "the old way" by addressing the individual lights until we have some confirmation from Signify that this feature is done.


fixes https://github.com/home-assistant/core/issues/67113

