### PR TITLE
Handle Hue discovery nupnp responding bad

### DIFF
--- a/aiohue/discovery.py
+++ b/aiohue/discovery.py
@@ -60,7 +60,7 @@ async def discover_nupnp(
                     pass
         return result
     except ClientError:
-        return None
+        return result
     finally:
         if not websession_provided:
             await websession.close()

--- a/aiohue/discovery.py
+++ b/aiohue/discovery.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientError
 
 from .util import normalize_bridge_id
 
@@ -59,6 +59,8 @@ async def discover_nupnp(
                 except Exception:  # noqa
                     pass
         return result
+    except ClientError:
+        return None
     finally:
         if not websession_provided:
             await websession.close()


### PR DESCRIPTION
Do not crash Hue setup if Hue NUPNP server is down.

Fixes https://github.com/home-assistant/core/issues/73129