### PR TITLE
Add monitor configuration type

### DIFF
--- a/aiohue/v2/models/entertainment_configuration.py
+++ b/aiohue/v2/models/entertainment_configuration.py
@@ -58,6 +58,9 @@ class EntertainmentConfigurationType(Enum):
     MUSIC = "music"  # Channels are organized for music synchronization
     THREEDEESPACE = "3dspace"  # Channels are organized to provide 3d spacial effects
     OTHER = "other"  # General use case "
+    MONITOR = (
+        "monitor"  # Channels are organized around content from one or several monitors
+    )
 
 
 class EntertainmentStatus(Enum):

--- a/aiohue/v2/models/entertainment_configuration.py
+++ b/aiohue/v2/models/entertainment_configuration.py
@@ -58,9 +58,7 @@ class EntertainmentConfigurationType(Enum):
     MUSIC = "music"  # Channels are organized for music synchronization
     THREEDEESPACE = "3dspace"  # Channels are organized to provide 3d spacial effects
     OTHER = "other"  # General use case "
-    MONITOR = (
-        "monitor"  # Channels are organized around content from one or several monitors
-    )
+    MONITOR = "monitor"  # Channels are organized around content from monitors
 
 
 class EntertainmentStatus(Enum):


### PR DESCRIPTION
"monitor" is a new configuration type for Entertainment Configurations and can be created through the latest Hue App.
Description is from the Hue API website.

Fixes #140 

Checked it by running the example vor v2 which gave the message that "monitor" was not supported, after updating the same example ran without the message