### PR TITLE
Updated rate limit statuscode

### DIFF
--- a/aiohue/v1/__init__.py
+++ b/aiohue/v1/__init__.py
@@ -16,9 +16,8 @@ from .lights import Lights
 from .scenes import Scenes
 from .sensors import Sensors
 
-MAX_RETRIES = (
-    25  # how many times do we retry on a 503 or 429 (bridge overload/rate limit)
-)
+# how many times do we retry on a 503 or 429 (bridge overload/rate limit)
+MAX_RETRIES = 25
 THROTTLE_CONCURRENT_REQUESTS = 1  # how many concurrent requests to the bridge
 THROTTLE_TIMESPAN = 0.25  # timespan/period (in seconds) for the rate limiting
 

--- a/aiohue/v2/__init__.py
+++ b/aiohue/v2/__init__.py
@@ -19,9 +19,8 @@ from .controllers.lights import LightsController
 from .controllers.scenes import ScenesController
 from .controllers.sensors import SensorsController
 
-MAX_RETRIES = (
-    25  # how many times do we retry on a 503 or 429 (bridge overload/rate limit)
-)
+# how many times do we retry on a 503 or 429 (bridge overload/rate limit)
+MAX_RETRIES = 25
 
 
 class HueBridgeV2:

--- a/aiohue/v2/__init__.py
+++ b/aiohue/v2/__init__.py
@@ -19,7 +19,9 @@ from .controllers.lights import LightsController
 from .controllers.scenes import ScenesController
 from .controllers.sensors import SensorsController
 
-MAX_RETRIES = 25  # how many times do we retry on a 503 (bridge overload/rate limit)
+MAX_RETRIES = (
+    25  # how many times do we retry on a 503 or 429 (bridge overload/rate limit)
+)
 
 
 class HueBridgeV2:
@@ -145,7 +147,7 @@ class HueBridgeV2:
         self, method: str, path: str, **kwargs
     ) -> Union[dict, List[dict]]:
         """Make request on the api and return response data."""
-        # The bridge will deny more than 3 requests at the same time with a 503 error.
+        # The bridge will deny more than 3 requests at the same time with a 429 error.
         # We guard ourselves from hitting this error by limiting the TCP Connector for aiohttp
         # but other apps/services are hitting the Hue bridge too so we still
         # might hit the rate limit/overload at some point so we have some retry logic if this happens.
@@ -157,14 +159,17 @@ class HueBridgeV2:
             if retries > 1:
                 retry_wait = 0.25 * retries
                 self.logger.debug(
-                    "Got 503 error from Hue bridge, retry request in %s seconds",
+                    "Got 503 or 429 error from Hue bridge, retry request in %s seconds",
                     retry_wait,
                 )
                 await asyncio.sleep(retry_wait)
 
             async with self.create_request(method, path, **kwargs) as resp:
-                # 503 means the bridge is rate limiting/overloaded, we should back off a bit.
+                # 503 means the service is temporarily unavailable, back off a bit.
                 if resp.status == 503:
+                    continue
+                # 429 means the bridge is rate limiting/overloaded, we should back off a bit.
+                if resp.status == 429:
                     continue
                 if resp.status == 403:
                     raise Unauthorized


### PR DESCRIPTION
On the Hue developer website there is a message about the rate limiting status code being updated https://developers.meethue.com/rate-limiting-status-code/

Quoted below for convenience

>Dear developers,
>
> The next Hue Bridge firmware release contains a change to the HTTP status code we respond with when your client exceeds the request rate limit. Previously this would return the wrong status code 503, and going forward the correct status code will be 429.
> 
> This only applies to HTTPS connections. The 503 status code can still happen, but only if the service you try to communicate with is temporarily unavailable (i.e. server side issue), whereas 429 will happen if your application is making to many requests in a short period of time (i.e. client side issue).
>
> Hue Developer Support

Since there is no specific bridge version mentioned I just added the 429 code same as 503 was done. This allows to work with bridges still on "before" versions and my assumption is that backing off when the service is temporarily unvailable is not a big issue.
