### PR TITLE
Add sparkle effect to fix new Festavia lights

### DIFF
--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -286,6 +286,7 @@ class EffectStatus(Enum):
     NO_EFFECT = "no_effect"
     CANDLE = "candle"
     FIRE = "fire"
+    SPARKLE = "sparkle"
     UNKNOWN = "unknown"
 
     @classmethod


### PR DESCRIPTION
The introduction of the new Hue Festavia Christmas lights introduced a new effect in the enum: sparkle.

Fixes https://github.com/home-assistant/core/issues/82264