### PR TITLE
Address changes of final V2 api release

### DIFF
--- a/aiohue/v1/groups.py
+++ b/aiohue/v1/groups.py
@@ -19,7 +19,7 @@ class Groups(APIItems):
 
     async def get_all_lights_group(self) -> "Group":
         """Return special all lights group."""
-        return Group("0", await self._request("get", "groups/0"), [], self._request)
+        return Group("0", await self._request("get", "groups/0"), self._request)
 
 
 class GroupState(TypedDict):

--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -92,6 +92,7 @@ class MatterFabricController(BaseResourcesController[Type[MatterFabric]]):
     item_cls = MatterFabric
     allow_parser_error = True
 
+
 class BehaviorScriptController(BaseResourcesController[Type[BehaviorScript]]):
     """Controller holding and managing HUE resources of type `behavior_script`."""
 
@@ -99,12 +100,14 @@ class BehaviorScriptController(BaseResourcesController[Type[BehaviorScript]]):
     item_cls = BehaviorScript
     allow_parser_error = True
 
+
 class BehaviorInstanceController(BaseResourcesController[Type[BehaviorInstance]]):
     """Controller holding and managing HUE resources of type `behavior_instance`."""
 
     item_type = ResourceTypes.BEHAVIOR_INSTANCE
     item_cls = BehaviorInstance
     allow_parser_error = True
+
 
 class ConfigController(
     GroupedControllerBase[
@@ -198,6 +201,6 @@ class ConfigController(
                 self.homekit,
                 self.matter,
                 self.matter_fabric,
-                self.behavior_script
+                self.behavior_script,
             ],
         )

--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -14,6 +14,8 @@ from ..models.homekit import Homekit
 from ..models.matter import Matter
 from ..models.matter_fabric import MatterFabric
 from ..models.resource import ResourceTypes
+from ..models.behavior_script import BehaviorScript
+from ..models.behavior_instance import BehaviorInstance
 from .base import BaseResourcesController, GroupedControllerBase
 
 if TYPE_CHECKING:
@@ -82,6 +84,27 @@ class MatterFabricController(BaseResourcesController[Type[MatterFabric]]):
     item_cls = MatterFabric
     allow_parser_error = True
 
+
+class MatterFabricController(BaseResourcesController[Type[MatterFabric]]):
+    """Controller holding and managing HUE resources of type `matter_fabric`."""
+
+    item_type = ResourceTypes.MATTER_FABRIC
+    item_cls = MatterFabric
+    allow_parser_error = True
+
+class BehaviorScriptController(BaseResourcesController[Type[BehaviorScript]]):
+    """Controller holding and managing HUE resources of type `behavior_script`."""
+
+    item_type = ResourceTypes.BEHAVIOR_SCRIPT
+    item_cls = BehaviorScript
+    allow_parser_error = True
+
+class BehaviorInstanceController(BaseResourcesController[Type[BehaviorInstance]]):
+    """Controller holding and managing HUE resources of type `behavior_instance`."""
+
+    item_type = ResourceTypes.BEHAVIOR_INSTANCE
+    item_cls = BehaviorInstance
+    allow_parser_error = True
 
 class ConfigController(
     GroupedControllerBase[
@@ -164,6 +187,7 @@ class ConfigController(
         self.homekit = HomekitController(bridge)
         self.matter = MatterController(bridge)
         self.matter_fabric = MatterFabricController(bridge)
+        self.behavior_script = BehaviorScriptController(bridge)
         super().__init__(
             bridge,
             [
@@ -174,5 +198,6 @@ class ConfigController(
                 self.homekit,
                 self.matter,
                 self.matter_fabric,
+                self.behavior_script
             ],
         )

--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -85,14 +85,6 @@ class MatterFabricController(BaseResourcesController[Type[MatterFabric]]):
     allow_parser_error = True
 
 
-class MatterFabricController(BaseResourcesController[Type[MatterFabric]]):
-    """Controller holding and managing HUE resources of type `matter_fabric`."""
-
-    item_type = ResourceTypes.MATTER_FABRIC
-    item_cls = MatterFabric
-    allow_parser_error = True
-
-
 class BehaviorScriptController(BaseResourcesController[Type[BehaviorScript]]):
     """Controller holding and managing HUE resources of type `behavior_script`."""
 

--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -10,6 +10,7 @@ from ..models.bridge_home import BridgeHome
 from ..models.device import Device
 from ..models.entertainment import Entertainment
 from ..models.entertainment_configuration import EntertainmentConfiguration
+from ..models.homekit import Homekit
 from ..models.resource import ResourceTypes
 from .base import BaseResourcesController, GroupedControllerBase
 
@@ -53,6 +54,14 @@ class EntertainmentConfigurationController(
 
     item_type = ResourceTypes.ENTERTAINMENT_CONFIGURATION
     item_cls = EntertainmentConfiguration
+    allow_parser_error = True
+
+
+class HomekitController(BaseResourcesController[Type[Homekit]]):
+    """Controller holding and managing HUE resources of type `homekit`."""
+
+    item_type = ResourceTypes.HOMEKIT
+    item_cls = Homekit
     allow_parser_error = True
 
 
@@ -134,6 +143,7 @@ class ConfigController(
         self.bridge_home = BridgeHomeController(bridge)
         self.entertainment = EntertainmentController(bridge)
         self.entertainment_configuration = EntertainmentConfigurationController(bridge)
+        self.homekit = HomekitController(bridge)
         super().__init__(
             bridge,
             [
@@ -141,5 +151,6 @@ class ConfigController(
                 self.bridge_home,
                 self.entertainment,
                 self.entertainment_configuration,
+                self.homekit,
             ],
         )

--- a/aiohue/v2/models/behavior_instance.py
+++ b/aiohue/v2/models/behavior_instance.py
@@ -1,13 +1,13 @@
 """
 Model(s) for behavior_instance resource on HUE bridge.
 
+API to manage instances of script.
 https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_behavior_instance
 """
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 
-from .behavior_script import BehaviorScriptMetadata
 from .resource import ResourceIdentifier, ResourceTypes
 
 
@@ -18,6 +18,13 @@ class BehaviorInstanceStatus(Enum):
     RUNNING = "running"
     DISABLED = "disabled"
     ERRORED = "errored"
+
+
+@dataclass
+class BehaviorInstanceMetadata:
+    """Represent BehaviorInstance Metadata object as used by BehaviorInstance resource."""
+
+    name: Optional[str] = None
 
 
 class DependencyLevel(Enum):
@@ -80,7 +87,7 @@ class BehaviorInstance:
 
     # last_error: required(string) - Last error happened while executing the script.
     last_error: str
-    metadata: BehaviorScriptMetadata
+    metadata: BehaviorInstanceMetadata
 
     # state: (object)
     # Script instance state.
@@ -90,3 +97,36 @@ class BehaviorInstance:
     id_v1: Optional[str] = None
     migrated_from: Optional[str] = None
     type: ResourceTypes = ResourceTypes.BEHAVIOR_INSTANCE
+
+
+@dataclass
+class BehaviorInstancePut:
+    """
+    Properties to send when updating/setting a `BehaviorInstance` object on the api.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_behavior_instance__put
+    """
+
+    enabled: Optional[bool] = None
+    # configuration: (object) Script configuration.
+    # This property is validated using ScriptDefinition.configuration_schema JSON schema.
+    configuration: Optional[dict] = None
+    # trigger: (object) Action that needs to be taken by this script instance.
+    # This property is validated using ScriptDefinition.trigger_schema JSON schema.
+    trigger: Optional[dict] = None
+    metadata: Optional[BehaviorInstanceMetadata] = None
+
+
+@dataclass
+class BehaviorInstancePost:
+    """
+    Properties to send when creating a `BehaviorInstance` object on the api.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#behavior_instance_post
+    """
+
+    script_id: str
+    enabled: bool
+    configuration: dict
+    metadata: Optional[BehaviorInstanceMetadata] = None
+    migrated_from: Optional[str] = None

--- a/aiohue/v2/models/behavior_script.py
+++ b/aiohue/v2/models/behavior_script.py
@@ -4,9 +4,24 @@ Model(s) for behavior_script resource on HUE bridge.
 https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_behavior_script
 """
 from dataclasses import dataclass
-from typing import Optional
+from enum import Enum
+from typing import List, Optional, Type
 
 from .resource import ResourceTypes
+
+
+class BehaviorScriptCategory:
+    """Enum with various Bahavior Script Categories."""
+
+    AUTOMATION = "automation"
+    ENTERTAINMENT = "entertainment"
+    ACCESSORY = "accessory"
+    OTHER = "other"
+
+    @classmethod
+    def _missing_(cls: Type, value: str):
+        """Set default enum member if an unknown value is provided."""
+        return BehaviorScriptCategory.OTHER
 
 
 @dataclass
@@ -14,6 +29,7 @@ class BehaviorScriptMetadata:
     """Represent BehaviorScript Metadata object as used by BehaviorScript resource."""
 
     name: Optional[str] = None
+    category: BehaviorScriptCategory = BehaviorScriptCategory.OTHER
 
 
 @dataclass
@@ -37,6 +53,9 @@ class BehaviorScript:
     # JSON schema of ScriptInstance.state property.
     state_schema: dict
     version: str
+    metadata: BehaviorScriptMetadata
+    supported_features: Optional[List[str]]
+    max_number_instances: Optional[int] = None
 
     id_v1: Optional[str] = None
     type: ResourceTypes = ResourceTypes.BEHAVIOR_SCRIPT

--- a/aiohue/v2/models/behavior_script.py
+++ b/aiohue/v2/models/behavior_script.py
@@ -1,6 +1,7 @@
 """
 Model(s) for behavior_script resource on HUE bridge.
 
+API to discover available scripts that can be instantiated
 https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_behavior_script
 """
 from dataclasses import dataclass
@@ -35,7 +36,7 @@ class BehaviorScriptMetadata:
 @dataclass
 class BehaviorScript:
     """
-    Represent a (full) `Button` resource when retrieved from the api.
+    Represent a (full) `BehaviorScript` resource when retrieved from the api.
 
     Available scripts that can be instantiated.
     https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_behavior_script_get

--- a/aiohue/v2/models/behavior_script.py
+++ b/aiohue/v2/models/behavior_script.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Type
 from .resource import ResourceTypes
 
 
-class BehaviorScriptCategory:
+class BehaviorScriptCategory(Enum):
     """Enum with various Bahavior Script Categories."""
 
     AUTOMATION = "automation"

--- a/aiohue/v2/models/behavior_script.py
+++ b/aiohue/v2/models/behavior_script.py
@@ -20,7 +20,7 @@ class BehaviorScriptCategory:
     OTHER = "other"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return BehaviorScriptCategory.OTHER
 

--- a/aiohue/v2/models/button.py
+++ b/aiohue/v2/models/button.py
@@ -21,7 +21,7 @@ class ButtonEvent(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: "ButtonEvent", value: object):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return ButtonEvent.UNKNOWN
 

--- a/aiohue/v2/models/button.py
+++ b/aiohue/v2/models/button.py
@@ -21,7 +21,7 @@ class ButtonEvent(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: "ButtonEvent", value: object):
         """Set default enum member if an unknown value is provided."""
         return ButtonEvent.UNKNOWN
 

--- a/aiohue/v2/models/device.py
+++ b/aiohue/v2/models/device.py
@@ -75,6 +75,8 @@ class DeviceProductData:
     product_archetype: DeviceArchetypes
     certified: bool
     software_version: str
+    # Hardware type; identified by Manufacturer code and ImageType
+    hardware_platform_type: Optional[str] = None
 
 
 @dataclass

--- a/aiohue/v2/models/device.py
+++ b/aiohue/v2/models/device.py
@@ -60,7 +60,7 @@ class DeviceArchetypes(Enum):
     CEILING_TUBE = "ceiling_tube"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return DeviceArchetypes.UNKNOWN_ARCHETYPE
 

--- a/aiohue/v2/models/device.py
+++ b/aiohue/v2/models/device.py
@@ -49,8 +49,15 @@ class DeviceArchetypes(Enum):
     HUE_PLAY = "hue_play"
     VINTAGE_BULB = "vintage_bulb"
     CHRISTMAS_TREE = "christmas_tree"
+    STRING_LIGHT = "string_light"
     HUE_CENTRIS = "hue_centris"
     HUE_LIGHTSTRIP_TV = "hue_lightstrip_tv"
+    HUE_LIGHTSTRIP_PC = "hue_lightstrip_pc"
+    HUE_TUBE = "hue_tube"
+    HUE_SIGNE = "hue_signe"
+    PENDANT_SPOT = "pendant_spot"
+    CEILING_HORIZONTAL = "ceiling_horizontal"
+    CEILING_TUBE = "ceiling_tube"
 
     @classmethod
     def _missing_(cls: Type, value: str):

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -303,8 +303,9 @@ class EffectsFeature:
 
     https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get
     """
-
+    effect: EffectStatus
     status: EffectStatus
+    effect_values: List[EffectStatus] = field(default_factory=list)
     status_values: List[EffectStatus] = field(default_factory=list)
 
 
@@ -342,8 +343,10 @@ class TimedEffectsFeature:
     https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get
     """
 
+    effect: TimedEffectStatus
     status: TimedEffectStatus
     status_values: List[TimedEffectStatus] = field(default_factory=list)
+    effect_values: List[TimedEffectStatus] = field(default_factory=list)
     # Duration is mandatory when timed effect is set except for no_effect.
     # Resolution decreases for a larger duration. e.g Effects with duration smaller
     # than a minute will be rounded to a resolution of 1s, while effects with duration

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -305,18 +305,18 @@ class EffectStatus(Enum):
 
 
 @dataclass
-class EffectsFeatureBase:
+class SceneEffectsFeature:
     """
-    Represent `EffectsFeature` base object as used by various Hue resources.
+    Represent `EffectsFeature` base object as used by scenes.
 
-    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_scene_get
     """
 
     effect: EffectStatus
 
 
 @dataclass
-class EffectsFeature(EffectsFeatureBase):
+class EffectsFeature:
     """
     Represent `EffectsFeature` object as used by various Hue resources.
 

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -94,7 +94,7 @@ class AlertEffectType(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return AlertEffectType.UNKNOWN
 
@@ -242,7 +242,7 @@ class DynamicStatus(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return DynamicStatus.UNKNOWN
 
@@ -299,7 +299,7 @@ class EffectStatus(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return EffectStatus.UNKNOWN
 
@@ -347,7 +347,7 @@ class TimedEffectStatus(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return TimedEffectStatus.UNKNOWN
 
@@ -504,7 +504,7 @@ class Signal(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return AlertEffectType.UNKNOWN
 
@@ -534,7 +534,7 @@ class PowerUpPreset(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return AlertEffectType.UNKNOWN
 

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional, Type
+from datetime import datetime
 
 
 @dataclass
@@ -457,3 +458,31 @@ class GradientFeature(GradientFeatureBase):
     # points_capable: required(integer)
     # Number of color points that gradient lamp is capable of showing with gradience.
     points_capable: int
+
+
+class Signal(Enum):
+    """Enum with various signals."""
+
+    NO_SIGNAL = "no_signal"
+    ON_OFF = "on_off"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Type, value: str):
+        """Set default enum member if an unknown value is provided."""
+        return AlertEffectType.UNKNOWN
+
+
+@dataclass
+class SignalingFeatureStatus:
+    """Indicates status of active signal. Not available when inactive."""
+
+    signal: Signal
+    estimated_end: datetime
+
+
+@dataclass
+class SignalingFeature:
+    """Feature containing signaling properties."""
+
+    status: SignalingFeatureStatus

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -402,8 +402,8 @@ class RecallFeature:
     # action: (RecallAction)
     # When writing active, the actions in the scene are executed on the target.
     action: Optional[RecallAction] = None
-    # status: (active)
-    # When writing active, the actions are executed on the target (legacy, use action insetad).
+    # status: (active, dynamic_palette)
+    # When writing active, the actions are executed on the target (legacy, use action instead).
     status: Optional[str] = None
     # duration: (integer – maximum: 6000000)
     # transition to the scene within the timeframe given by duration. Accuracy is in 100ms steps.

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -1,8 +1,8 @@
 """Feature Schemas used by various Hue resources."""
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Type
-from datetime import datetime
 
 
 @dataclass
@@ -303,6 +303,7 @@ class EffectsFeature:
 
     https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get
     """
+
     effect: EffectStatus
     status: EffectStatus
     effect_values: List[EffectStatus] = field(default_factory=list)
@@ -502,3 +503,118 @@ class SignalingFeature:
     """Feature containing signaling properties."""
 
     status: SignalingFeatureStatus
+
+
+class PowerUpPreset(Enum):
+    """Enum with available powerup presets."""
+
+    SAFETY = "safety"
+    POWERFAIL = "powerfail"
+    LAST_ON_STATE = "last_on_state"
+    CUSTOM = "custom"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Type, value: str):
+        """Set default enum member if an unknown value is provided."""
+        return AlertEffectType.UNKNOWN
+
+
+class PowerUpFeatureOnMode(Enum):
+    """Enum with available powerup on modes."""
+
+    ON = "on"
+    TOGGLE = "toggle"
+    PREVIOUS = "previous"
+
+
+@dataclass
+class PowerUpFeatureOnState:
+    """
+    State to activate after powerup.
+
+    On will use the value specified in the “on” property.
+    When setting mode “on”, the on property must be included.
+    Toggle will alternate between on and off on each subsequent power toggle.
+    Previous will return to the state it was in before powering off.
+    """
+
+    mode: PowerUpFeatureOnMode
+    on: Optional[OnFeature] = None
+
+
+class PowerUpFeatureDimmingMode(Enum):
+    """Enum with available powerup dimming modes."""
+
+    DIMMING = "dimming"
+    PREVIOUS = "previous"
+
+
+@dataclass
+class PowerUpFeatureDimmingState:
+    """
+    Dimming will set the brightness to the specified value after power up.
+
+    When setting mode “dimming”, the dimming property must be included.
+    Previous will set brightness to the state it was in before powering off.
+    """
+
+    mode: PowerUpFeatureDimmingMode
+    dimming: Optional[DimmingFeatureBase] = None
+
+
+class PowerUpFeatureColorMode(Enum):
+    """Enum with available powerup color modes."""
+
+    COLOR_TEMPERATURE = "color_temperature"
+    COLOR = "color"
+    PREVIOUS = "previous"
+
+
+@dataclass
+class PowerUpFeatureColorState:
+    """
+    Color state to activate after powerup.
+
+    Availability of “color_temperature” and “color” modes depend on the capabilities of the lamp.
+    Colortemperature will set the colortemperature to the specified value after power up.
+    When setting color_temperature, the color_temperature property must be included Color will
+    set the color tot he specified value after power up. When setting color mode,
+    the color property must be included Previous will set color to the state
+    it was in before powering off.
+    """
+
+    mode: PowerUpFeatureColorMode
+    color_temperature: Optional[ColorTemperatureFeatureBase] = None
+    color: Optional[ColorFeatureBase] = None
+
+
+@dataclass
+class PowerUpFeature:
+    """
+    Feature containing properties to configure powerup behaviour of a lightsource.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get
+    """
+
+    # NOTE: When setting the custom preset the additional properties can be set.
+    # For all other presets, no other properties can be included.
+    preset: PowerUpPreset
+    configured: bool
+    on: PowerUpFeatureOnState
+    dimming: Optional[PowerUpFeatureDimmingState] = None
+    color: Optional[PowerUpFeatureColorState] = None
+
+
+@dataclass
+class PowerUpFeaturePut:
+    """
+    PowerUp feature properties that can be set/updated with a PUT request.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light__id__put
+    """
+
+    preset: PowerUpPreset
+    on: Optional[PowerUpFeatureOnState] = None
+    dimming: Optional[PowerUpFeatureDimmingState] = None
+    color: Optional[PowerUpFeatureColorState] = None

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -297,14 +297,23 @@ class EffectStatus(Enum):
 
 
 @dataclass
-class EffectsFeature:
+class EffectsFeatureBase:
+    """
+    Represent `EffectsFeature` base object as used by various Hue resources.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get
+    """
+
+    effect: EffectStatus
+
+@dataclass
+class EffectsFeature(EffectsFeatureBase):
     """
     Represent `EffectsFeature` object as used by various Hue resources.
 
     https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get
     """
 
-    effect: EffectStatus
     status: EffectStatus
     effect_values: List[EffectStatus] = field(default_factory=list)
     status_values: List[EffectStatus] = field(default_factory=list)
@@ -377,6 +386,7 @@ class RecallAction(Enum):
     """Enum with available recall actions."""
 
     ACTIVE = "active"
+    STATIC = "static"
     DYNAMIC_PALETTE = "dynamic_palette"
 
 
@@ -400,7 +410,7 @@ class RecallFeature:
     duration: Optional[int] = None
     # dimming: (DimmingFeature)
     # override the scene dimming/brightness
-    dimming: Optional[DimmingFeature] = None
+    dimming: Optional[DimmingFeatureBase] = None
 
 
 @dataclass

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -115,7 +115,15 @@ class AlertFeaturePut:
 
 @dataclass
 class IdentifyFeature:
-    """Represent IdentifyFeature object as used by the Hue api."""
+    """
+    Represent IdentifyFeature object as used by the Hue api.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_device__id__put
+    identify: Triggers a visual identification sequence, current implemented as
+    (which can change in the future):
+    Bridge performs Zigbee LED identification cycles for 5 seconds Lights perform one breathe
+    cycle Sensors perform LED identification cycles for 15 seconds
+    """
 
     # only used in PUT requests on device
     action: str = "identify"
@@ -305,6 +313,7 @@ class EffectsFeatureBase:
     """
 
     effect: EffectStatus
+
 
 @dataclass
 class EffectsFeature(EffectsFeatureBase):

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -438,6 +438,14 @@ class GradientPoint:
     color: ColorFeatureBase
 
 
+class GradientMode:
+    """Mode of the Gradient feature."""
+
+    INTERPOLATED_PALETTE = "interpolated_palette"
+    INTERPOLATED_PALETTE_MIRRORED = "interpolated_palette_mirrored"
+    RANDOM_PIXELATED = "random_pixelated"
+
+
 @dataclass
 class GradientFeatureBase:
     """Represent GradientFeature base properties."""
@@ -458,6 +466,11 @@ class GradientFeature(GradientFeatureBase):
     # points_capable: required(integer)
     # Number of color points that gradient lamp is capable of showing with gradience.
     points_capable: int
+    # mode: Mode in which the points are currently being deployed.
+    # If not provided during PUT/POST it will be defaulted to interpolated_palette
+    mode: GradientMode = GradientMode.INTERPOLATED_PALETTE
+    mode_values: List[GradientMode] = field(default_factory=list)
+    pixel_count: Optional[int] = None  # Number of pixels in the device
 
 
 class Signal(Enum):

--- a/aiohue/v2/models/grouped_light.py
+++ b/aiohue/v2/models/grouped_light.py
@@ -9,9 +9,9 @@ from typing import Optional
 from .feature import (
     AlertFeature,
     AlertFeaturePut,
-    ColorFeatureBase,
+    ColorFeaturePut,
     ColorTemperatureDeltaFeaturePut,
-    ColorTemperatureFeatureBase,
+    ColorTemperatureFeaturePut,
     DimmingDeltaFeaturePut,
     DimmingFeatureBase,
     DynamicsFeaturePut,
@@ -47,8 +47,8 @@ class GroupedLightPut:
     on: Optional[OnFeature] = None
     dimming: Optional[DimmingFeatureBase] = None
     dimming_delta: Optional[DimmingDeltaFeaturePut] = None
-    color_temperature: Optional[ColorTemperatureFeatureBase] = None
+    color_temperature: Optional[ColorTemperatureFeaturePut] = None
     color_temperature_delta: Optional[ColorTemperatureDeltaFeaturePut] = None
-    color: Optional[ColorFeatureBase] = None
+    color: Optional[ColorFeaturePut] = None
     dynamics: Optional[DynamicsFeaturePut] = None
     alert: Optional[AlertFeaturePut] = None

--- a/aiohue/v2/models/grouped_light.py
+++ b/aiohue/v2/models/grouped_light.py
@@ -31,6 +31,7 @@ class GroupedLight:
     id: str
     id_v1: Optional[str] = None
     on: Optional[OnFeature] = None
+    dimming: Optional[DimmingFeatureBase] = None
     alert: Optional[AlertFeature] = None
     type: ResourceTypes = ResourceTypes.GROUPED_LIGHT
 

--- a/aiohue/v2/models/light.py
+++ b/aiohue/v2/models/light.py
@@ -26,6 +26,8 @@ from .feature import (
     GradientFeature,
     GradientFeatureBase,
     OnFeature,
+    PowerUpFeature,
+    PowerUpFeaturePut,
     SignalingFeature,
     TimedEffectsFeature,
     TimedEffectsFeaturePut,
@@ -80,6 +82,7 @@ class Light:
     gradient: Optional[GradientFeature] = None
     effects: Optional[EffectsFeature] = None
     timed_effects: Optional[TimedEffectsFeature] = None
+    powerup: Optional[PowerUpFeature] = None
 
     type: ResourceTypes = ResourceTypes.LIGHT
 
@@ -144,3 +147,4 @@ class LightPut:
     gradient: Optional[GradientFeatureBase] = None
     effects: Optional[EffectsFeaturePut] = None
     timed_effects: Optional[TimedEffectsFeaturePut] = None
+    powerup: Optional[PowerUpFeaturePut] = None

--- a/aiohue/v2/models/light.py
+++ b/aiohue/v2/models/light.py
@@ -26,6 +26,7 @@ from .feature import (
     GradientFeature,
     GradientFeatureBase,
     OnFeature,
+    SignalingFeature,
     TimedEffectsFeature,
     TimedEffectsFeaturePut,
 )
@@ -75,6 +76,7 @@ class Light:
     color: Optional[ColorFeature] = None
     dynamics: Optional[DynamicsFeature] = None
     alert: Optional[AlertFeature] = None
+    signaling: Optional[SignalingFeature] = None
     gradient: Optional[GradientFeature] = None
     effects: Optional[EffectsFeature] = None
     timed_effects: Optional[TimedEffectsFeature] = None

--- a/aiohue/v2/models/light.py
+++ b/aiohue/v2/models/light.py
@@ -66,7 +66,6 @@ class Light:
 
     id: str
     owner: ResourceIdentifier
-    metadata: LightMetaData
     on: OnFeature
     mode: LightMode
 
@@ -96,13 +95,6 @@ class Light:
     def supports_color_temperature(self) -> bool:
         """Return if this light supports color_temperature control."""
         return self.color_temperature is not None
-
-    @property
-    def name(self) -> Optional[str]:
-        """Return name from metadata."""
-        if self.metadata is not None:
-            return self.metadata.name
-        return None
 
     @property
     def is_on(self) -> bool:

--- a/aiohue/v2/models/relative_rotary.py
+++ b/aiohue/v2/models/relative_rotary.py
@@ -32,7 +32,21 @@ class RelativeRotaryDirection(Enum):
 
 @dataclass
 class RelativeRotaryRotation:
-    """Represent Rotation object as used by the Hue api."""
+    """
+    Represent Rotation object as used by the Hue api.
+    
+    direction: required(one of clock_wise, counter_clock_wise)
+    A rotation opposite to the previous rotation, will always start with new start command.
+
+    steps: required(integer - minimum: 0 - maximum: 32767)
+    amount of rotation since previous event in case of repeat, 
+    amount of rotation since start in case of a start_event. 
+    Resolution = 1000 steps / 360 degree rotation.
+
+    duration: required(integer - minimum: 0 - maximum: 65534)
+    duration of rotation since previous event in case of repeat, 
+    amount of rotation since start in case of a start_event. duration is specified in miliseconds.
+    """
 
     direction: RelativeRotaryDirection
     duration: int

--- a/aiohue/v2/models/relative_rotary.py
+++ b/aiohue/v2/models/relative_rotary.py
@@ -18,7 +18,7 @@ class RelativeRotaryAction(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return RelativeRotaryAction.UNKNOWN
 

--- a/aiohue/v2/models/relative_rotary.py
+++ b/aiohue/v2/models/relative_rotary.py
@@ -34,17 +34,17 @@ class RelativeRotaryDirection(Enum):
 class RelativeRotaryRotation:
     """
     Represent Rotation object as used by the Hue api.
-    
+
     direction: required(one of clock_wise, counter_clock_wise)
     A rotation opposite to the previous rotation, will always start with new start command.
 
     steps: required(integer - minimum: 0 - maximum: 32767)
-    amount of rotation since previous event in case of repeat, 
-    amount of rotation since start in case of a start_event. 
+    amount of rotation since previous event in case of repeat,
+    amount of rotation since start in case of a start_event.
     Resolution = 1000 steps / 360 degree rotation.
 
     duration: required(integer - minimum: 0 - maximum: 65534)
-    duration of rotation since previous event in case of repeat, 
+    duration of rotation since previous event in case of repeat,
     amount of rotation since start in case of a start_event. duration is specified in miliseconds.
     """
 

--- a/aiohue/v2/models/resource.py
+++ b/aiohue/v2/models/resource.py
@@ -50,7 +50,7 @@ class ResourceTypes(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return ResourceTypes.UNKNOWN
 

--- a/aiohue/v2/models/room.py
+++ b/aiohue/v2/models/room.py
@@ -121,3 +121,27 @@ class Room:
             (x.rid for x in self.services if x.rtype == ResourceTypes.GROUPED_LIGHT),
             None,
         )
+
+
+@dataclass
+class RoomPut:
+    """
+    Properties to send when updating/setting a `Room` object on the api.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_room__id__put
+    """
+
+    children: Optional[List[ResourceIdentifier]] = None
+    metadata: Optional[RoomMetaDataPut] = None
+
+
+@dataclass
+class RoomPost:
+    """
+    Properties to send when creating a `Room` object on the api.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_room_post
+    """
+
+    children: List[ResourceIdentifier]
+    metadata: RoomMetaData

--- a/aiohue/v2/models/room.py
+++ b/aiohue/v2/models/room.py
@@ -56,7 +56,7 @@ class RoomArchetype(Enum):
     OTHER = "other"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return RoomArchetype.OTHER
 

--- a/aiohue/v2/models/scene.py
+++ b/aiohue/v2/models/scene.py
@@ -11,11 +11,11 @@ from .feature import (
     ColorTemperatureFeatureBase,
     DimmingFeatureBase,
     DynamicsFeaturePut,
-    EffectsFeatureBase,
     GradientFeatureBase,
     OnFeature,
     PaletteFeature,
     RecallFeature,
+    SceneEffectsFeature,
 )
 from .resource import ResourceIdentifier, ResourceTypes
 
@@ -29,7 +29,7 @@ class ActionAction:
     color: Optional[ColorFeatureBase] = None
     color_temperature: Optional[ColorTemperatureFeatureBase] = None
     gradient: Optional[GradientFeatureBase] = None
-    effects: Optional[EffectsFeatureBase] = None
+    effects: Optional[SceneEffectsFeature] = None
     dynamics: Optional[DynamicsFeaturePut] = None
 
 

--- a/aiohue/v2/models/scene.py
+++ b/aiohue/v2/models/scene.py
@@ -10,6 +10,8 @@ from .feature import (
     ColorFeatureBase,
     ColorTemperatureFeatureBase,
     DimmingFeatureBase,
+    DynamicsFeaturePut,
+    EffectsFeatureBase,
     GradientFeatureBase,
     OnFeature,
     PaletteFeature,
@@ -27,6 +29,8 @@ class ActionAction:
     color: Optional[ColorFeatureBase] = None
     color_temperature: Optional[ColorTemperatureFeatureBase] = None
     gradient: Optional[GradientFeatureBase] = None
+    effects: Optional[EffectsFeatureBase] = None
+    dynamics: Optional[DynamicsFeaturePut] = None
 
 
 @dataclass
@@ -72,6 +76,8 @@ class Scene:
     palette: PaletteFeature
     # speed: required(number – minimum: 0 – maximum: 1)
     speed: float
+    # auto_dynamic: whether to automatically start the scene dynamically on active recall
+    auto_dynamic: bool
 
     # optional params
     id_v1: Optional[str] = None
@@ -95,6 +101,7 @@ class ScenePut:
     # speed: (number – minimum: 0 – maximum: 1)
     # Speed of dynamic palette for this scene
     speed: Optional[float] = None
+    auto_dynamic: Optional[bool] = None
 
 
 @dataclass
@@ -110,4 +117,5 @@ class ScenePost:
     actions: List[Action]
     palette: Optional[PaletteFeature] = None
     speed: Optional[float] = None
+    auto_dynamic: Optional[bool] = None
     type: ResourceTypes = ResourceTypes.SCENE

--- a/aiohue/v2/models/smart_scene.py
+++ b/aiohue/v2/models/smart_scene.py
@@ -30,7 +30,7 @@ class SmartSceneState(Enum):
     INACTIVE = "inactive"
 
     @classmethod
-    def _missing_(cls: Type, value: str):
+    def _missing_(cls: Type, value: object):
         """Set default enum member if an unknown value is provided."""
         return SmartSceneState.INACTIVE
 

--- a/aiohue/v2/models/zone.py
+++ b/aiohue/v2/models/zone.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 
 from .resource import ResourceTypes
-from .room import Room
+from .room import Room, RoomPut, RoomPost
 
 
 @dataclass
@@ -20,3 +20,21 @@ class Zone(Room):
     """
 
     type: ResourceTypes = ResourceTypes.ZONE
+
+
+@dataclass
+class ZonePut(RoomPut):
+    """
+    Properties to send when updating/setting a `Zone` object on the api.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_zone__id__put
+    """
+
+
+@dataclass
+class ZonePost(RoomPost):
+    """
+    Properties to send when creating a `Zone` object on the api.
+
+    https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_zone_post
+    """

--- a/examples/v2_bridge.py
+++ b/examples/v2_bridge.py
@@ -30,27 +30,22 @@ async def main():
         print(bridge.config.bridge_device)
 
         print()
-        print("found lights:")
-        for item in bridge.lights:
-            print(item.metadata.name)
-
-        print()
         print("found devices:")
         for item in bridge.devices:
             print(item.metadata.name)
 
         # turn on a light
         light = next(x for x in bridge.lights.items if x.supports_color)
-        print("Turning on light", light.name)
+        print("Turning on light", light.id)
         await bridge.lights.turn_on(light.id)
         await asyncio.sleep(1)
-        print("Set brightness 100 to light", light.name)
+        print("Set brightness 100 to light", light.id)
         await bridge.lights.set_brightness(light.id, 100, 2000)
         await asyncio.sleep(2)
-        print("Set color to light", light.name)
+        print("Set color to light", light.id)
         await bridge.lights.set_color(light.id, 0.141, 0.123, 2000)
         await asyncio.sleep(1)
-        print("Turning off light", light.name)
+        print("Turning off light", light.id)
         await bridge.lights.turn_off(light.id, 2000)
 
         print()


### PR DESCRIPTION
Signify has now officially released the definitive spec of the V2 API (and V1 is now deprecated). 
I've corrected all models so that they 100% match the official specifications.

NOTE: While working on this, I noticed some type issues by running mypy. We'll need to address that in a seperate PR and setup CI to run mypy on the v2 code.