### PR TITLE
Mark auto_dynamic attribute optional on scene resource

### DIFF
--- a/aiohue/v2/models/scene.py
+++ b/aiohue/v2/models/scene.py
@@ -77,7 +77,7 @@ class Scene:
     # speed: required(number – minimum: 0 – maximum: 1)
     speed: float
     # auto_dynamic: whether to automatically start the scene dynamically on active recall
-    auto_dynamic: bool
+    auto_dynamic: Optional[bool] = None
 
     # optional params
     id_v1: Optional[str] = None


### PR DESCRIPTION
This attribute is only present on recent bridge firmware versions.
To allow for a little transition period, mark it optional to prevent errors for people running older bridge versions.

Fixes #185 