### PR TITLE
add metadata to Light-class

### DIFF
--- a/aiohue/v2/models/light.py
+++ b/aiohue/v2/models/light.py
@@ -70,6 +70,7 @@ class Light:
     owner: ResourceIdentifier
     on: OnFeature
     mode: LightMode
+    metadata: LightMetaData
 
     id_v1: str | None = None
     dimming: DimmingFeature | None = None


### PR DESCRIPTION
## What was changed
metadata was added to the `Light`-class. There were already a dataclass for it `LightMetaData`, but it was not included in `Light`. For all lights I have available, there have have always been a `metadata`-key.

## Why was it changed
I wanted to use the aiohue as a base for a CLI-app and I wanted a way to print out the assigned names and IDs of the light devices I have in my own network. It didn't work with:
```python
async with HueBridgeV2(host=<HOST>, app_key=<APP_KEY>) as bridge:
    for item in bridge.lights:
        print(f"{item.metadata.name:-<30} {item.id}")
```

Looking at the example in examples/v2_bridge.py:
```python
async with HueBridgeV2(host=<HOST>, app_key=<APP_KEY>) as bridge:
        for item in bridge.devices:
            print(item.metadata.name)
```
It was possible to get the names and IDs, but it is not the IDs that you can use to control the lights. It was very confusing at first.

With the proposed change, it is possible to get a list of the assigned names to the lights together with the IDs that can be used together to control a light, such as turning on/off or set brightness.

## Edit
Just after creating this PR I found out that `metadata` on the `/resource/light/{id}`-endpoint is deprecated. It is written that you should use the `metadata` for the `/resource/device/{id}`-endpoint. I guess the only way is to do something like:
```python
async with HueBridgeV2(host=<HOST>, app_key=<APP_KEY>) as bridge:
    for item in bridge.devices:
        if item.lights:
            print(f"{item.metadata.name} - {item.lights}")
```

Maybe it is possible to add something similar as an example instead?