### PR TITLE
Allow a scene's `palette` to be absent.

### DIFF
--- a/aiohue/v2/models/scene.py
+++ b/aiohue/v2/models/scene.py
@@ -72,7 +72,7 @@ class Scene:
     # actions: required(array of Action)
     # List of actions to be executed synchronously on recall
     actions: list[Action]
-    palette: PaletteFeature
+    palette: PaletteFeature | None
     # speed: required(number – minimum: 0 – maximum: 1)
     speed: float
     # auto_dynamic: whether to automatically start the scene dynamically on active recall


### PR DESCRIPTION
The `palette` key is not marked as required in the [Hue v2 API documentation](https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_scene_get), so we should be able to handle its absence here.

Resolves #259.