### PR TITLE
Treat EffectStatus.NO_EFFECT the same as None

### DIFF
--- a/aiohue/v2/controllers/lights.py
+++ b/aiohue/v2/controllers/lights.py
@@ -82,7 +82,7 @@ class LightsController(BaseResourcesController[type[Light]]):
             update_obj.color = ColorFeaturePut(xy=ColorPoint(*color_xy))
         if color_temp is not None:
             update_obj.color_temperature = ColorTemperatureFeaturePut(mirek=color_temp)
-        if transition_time is not None and effect is None:
+        if transition_time is not None and (effect is None or effect == EffectStatus.NO_EFFECT):
             update_obj.dynamics = DynamicsFeaturePut(duration=transition_time)
         if alert is not None:
             update_obj.alert = AlertFeaturePut(action=alert)

--- a/aiohue/v2/controllers/lights.py
+++ b/aiohue/v2/controllers/lights.py
@@ -82,7 +82,7 @@ class LightsController(BaseResourcesController[type[Light]]):
             update_obj.color = ColorFeaturePut(xy=ColorPoint(*color_xy))
         if color_temp is not None:
             update_obj.color_temperature = ColorTemperatureFeaturePut(mirek=color_temp)
-        if transition_time is not None and (effect is None or effect == EffectStatus.NO_EFFECT):
+        if transition_time is not None and effect in (None, EffectStatus.NO_EFFECT):
             update_obj.dynamics = DynamicsFeaturePut(duration=transition_time)
         if alert is not None:
             update_obj.alert = AlertFeaturePut(action=alert)


### PR DESCRIPTION
Full bug report in https://github.com/home-assistant/core/issues/106779. This seems like the easiest fix to me but I have no idea if this breaks anything else. Looks to me like both these values should do the same thing anyway.