### PR TITLE
SignalingFeatureStatus is missing a type in the dataclass definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,3 @@ The biggest advantage of the V2 API is that it supports event based updates so p
 ## Contribution guidelines
 
 Object hierarchy and property/method names should match the Philips Hue API.
-
-XX

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ The biggest advantage of the V2 API is that it supports event based updates so p
 ## Contribution guidelines
 
 Object hierarchy and property/method names should match the Philips Hue API.
+
+XX

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -523,7 +523,7 @@ class Signal(Enum):
 class SignalingFeatureStatus:
     """Indicates status of active signal. Not available when inactive."""
 
-    signal: Signal | Signal = Signal.UNKNOWN
+    signal: Signal | None = Signal.UNKNOWN
     estimated_end: datetime | None = None
     colors: list[ColorFeatureBase] | None = None
 

--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -523,7 +523,7 @@ class Signal(Enum):
 class SignalingFeatureStatus:
     """Indicates status of active signal. Not available when inactive."""
 
-    signal: Signal = Signal.UNKNOWN
+    signal: Signal | Signal = Signal.UNKNOWN
     estimated_end: datetime | None = None
     colors: list[ColorFeatureBase] | None = None
 


### PR DESCRIPTION
When attempting to turn the dataclass back into a dict for MQTT purposes, asdict fails on SignalingFeatureStatus.  It is missing a type for the Signal.  Nearby code and classes are defined correctly.

This is a one-line change.