### PR TITLE
Patch ghost events from button and relative_rotary resources

### DIFF
--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -234,10 +234,13 @@ class BaseResourcesController(Generic[CLIPResource]):
             # in fact this is a feature request to Signify to handle these stateless
             # device events in a different way:
             # https://developers.meethue.com/forum/t/differentiate-stateless-events/6627
-            if self.item_type == ResourceTypes.BUTTON and not evt_data.get("button", {}).get("button_report"):
+            if self.item_type == ResourceTypes.BUTTON and not evt_data.get(
+                "button", {}
+            ).get("button_report"):
                 return
             if self.item_type == ResourceTypes.RELATIVE_ROTARY and not evt_data.get(
-                    "relative_rotary", {}).get("rotary_report"):
+                "relative_rotary", {}
+            ).get("rotary_report"):
                 return
         else:
             # ignore all other events

--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -234,11 +234,10 @@ class BaseResourcesController(Generic[CLIPResource]):
             # in fact this is a feature request to Signify to handle these stateless
             # device events in a different way:
             # https://developers.meethue.com/forum/t/differentiate-stateless-events/6627
-            if self.item_type == ResourceTypes.BUTTON and not evt_data.get("button"):
+            if self.item_type == ResourceTypes.BUTTON and not evt_data.get("button", {}).get("button_report"):
                 return
             if self.item_type == ResourceTypes.RELATIVE_ROTARY and not evt_data.get(
-                "relative_rotary"
-            ):
+                    "relative_rotary", {}).get("rotary_report"):
                 return
         else:
             # ignore all other events


### PR DESCRIPTION
I think this is not a proper fix as it is now dropping the event from button resources when `button` or `button.button_report` (or `relative_rotary` or `relative_rotary.rotary_report` for relative_rotary resources) are absent, while there might be other changes in the event that are relevant upstream. Since there was already code to drop the events, I expect the additional condition isn't going to hurt functionality. This should at least make the problem go away.