### PR TITLE
Remove use of deprecated `last_event` for button events

### DIFF
--- a/aiohue/v2/controllers/sensors.py
+++ b/aiohue/v2/controllers/sensors.py
@@ -110,7 +110,9 @@ class ButtonController(BaseResourcesController[type[Button]]):
                 if cur_event == ButtonEvent.SHORT_RELEASE:
                     break
                 # send REPEAT until short release is received
-                btn_resource["button"]["button_report"]["event"] = ButtonEvent.REPEAT.value
+                btn_resource["button"]["button_report"]["event"] = (
+                    ButtonEvent.REPEAT.value
+                )
                 await self._handle_event(EventType.RESOURCE_UPDATED, btn_resource)
                 await asyncio.sleep(0.5)
                 count += 1
@@ -121,7 +123,9 @@ class ButtonController(BaseResourcesController[type[Button]]):
             # Note that the button will also fire the SHORT_RELEASE event if it's released within
             # those 10 seconds.
             if count > 1:
-                btn_resource["button"]["button_report"]["event"] = ButtonEvent.LONG_RELEASE.value
+                btn_resource["button"]["button_report"]["event"] = (
+                    ButtonEvent.LONG_RELEASE.value
+                )
                 await self._handle_event(EventType.RESOURCE_UPDATED, btn_resource)
             self._logger.debug("Long press workaround for FOH switch completed.")
 

--- a/aiohue/v2/controllers/sensors.py
+++ b/aiohue/v2/controllers/sensors.py
@@ -73,7 +73,7 @@ class ButtonController(BaseResourcesController[type[Button]]):
         # Handle longpress workaround if needed
         if not (
             evt_type == EventType.RESOURCE_UPDATED
-            and evt_data.get("button", {}).get("last_event")
+            and evt_data.get("button", {}).get("button_report", {}).get("event")
             == ButtonEvent.INITIAL_PRESS.value
         ):
             return
@@ -106,11 +106,11 @@ class ButtonController(BaseResourcesController[type[Button]]):
         count = 0
         try:
             while count <= 20:  # = max 10 seconds
-                cur_event = self._items[id].button.last_event
+                cur_event = self._items[id].button.button_report.event
                 if cur_event == ButtonEvent.SHORT_RELEASE:
                     break
                 # send REPEAT until short release is received
-                btn_resource["button"]["last_event"] = ButtonEvent.REPEAT.value
+                btn_resource["button"]["button_report"]["event"] = ButtonEvent.REPEAT.value
                 await self._handle_event(EventType.RESOURCE_UPDATED, btn_resource)
                 await asyncio.sleep(0.5)
                 count += 1
@@ -121,7 +121,7 @@ class ButtonController(BaseResourcesController[type[Button]]):
             # Note that the button will also fire the SHORT_RELEASE event if it's released within
             # those 10 seconds.
             if count > 1:
-                btn_resource["button"]["last_event"] = ButtonEvent.LONG_RELEASE.value
+                btn_resource["button"]["button_report"]["event"] = ButtonEvent.LONG_RELEASE.value
                 await self._handle_event(EventType.RESOURCE_UPDATED, btn_resource)
             self._logger.debug("Long press workaround for FOH switch completed.")
 

--- a/tests/fixtures/v2_resources.json
+++ b/tests/fixtures/v2_resources.json
@@ -1201,7 +1201,9 @@
   },
   {
     "button": {
-      "last_event": "short_release"
+      "button_report": {
+        "event": "short_release"
+      }
     },
     "id": "c658d3d8-a013-4b81-8ac6-78b248537e70",
     "id_v1": "/sensors/50",
@@ -1240,7 +1242,9 @@
   },
   {
     "button": {
-      "last_event": "short_release"
+      "button_report": {
+        "event": "short_release"
+      }
     },
     "id": "7f1ab9f6-cc2b-4b40-9011-65e2af153f75",
     "id_v1": "/sensors/10",
@@ -1279,7 +1283,9 @@
   },
   {
     "button": {
-      "last_event": "short_release"
+      "button_report": {
+        "event": "short_release"
+      }
     },
     "id": "31cffcda-efc2-401f-a152-e10db3eed232",
     "id_v1": "/sensors/5",


### PR DESCRIPTION
Use `button_report.event` instead.