### PR TITLE
Handle EffectStatus.NO_EFFECT correctly

### DIFF
--- a/aiohue/v2/controllers/lights.py
+++ b/aiohue/v2/controllers/lights.py
@@ -92,11 +92,13 @@ class LightsController(BaseResourcesController[type[Light]]):
         if alert is not None:
             update_obj.alert = AlertFeaturePut(action=alert)
 
-        # for timed_effects feature, transition time is used for duration
-        if effect is not None and isinstance(effect, TimedEffectStatus):
-            update_obj.timed_effects = TimedEffectsFeaturePut(
-                effect=effect, duration=transition_time
-            )
-        elif effect is not None:
-            update_obj.effects = EffectsFeaturePut(effect=effect)
+        if effect not in (None, EffectStatus.NO_EFFECT):
+            # for timed_effects feature, transition time is used for duration
+            if isinstance(effect, TimedEffectStatus):
+                update_obj.timed_effects = TimedEffectsFeaturePut(
+                    effect=effect, duration=transition_time
+                )
+            else:
+                update_obj.effects = EffectsFeaturePut(effect=effect)
+
         await self.update(id, update_obj)


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/home-assistant/core/issues/122165

https://github.com/home-assistant-libs/aiohue/pull/281 was mentioned there, and I think the handling of `EffectStatus.NO_EFFECT` was not complete. I have not been able to test this PR though.