### PR TITLE
Add missing sunset timed effect

### DIFF
--- a/aiohue/v2/models/feature.py
+++ b/aiohue/v2/models/feature.py
@@ -348,6 +348,7 @@ class TimedEffectStatus(Enum):
 
     NO_EFFECT = "no_effect"
     SUNRISE = "sunrise"
+    SUNSET = "sunset"
     UNKNOWN = "unknown"
 
     @classmethod


### PR DESCRIPTION
It is returned for my lights by the Hue API:
```json
            "timed_effects": {
                "status_values": [
                    "no_effect",
                    "sunrise",
                    "sunset"
                ],
                "status": "no_effect",
                "effect_values": [
                    "no_effect",
                    "sunrise",
                    "sunset"
                ]
            },
```

It is also mentioned in the documentation: https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get