### PR TITLE
Backwards compatibility handling on last_event for button and relative_rotary

### DIFF
--- a/aiohue/util.py
+++ b/aiohue/util.py
@@ -129,6 +129,11 @@ def parse_utc_timestamp(datetimestr: str):
     return datetime.fromisoformat(datetimestr.replace("Z", "+00:00"))
 
 
+def format_utc_timestamp(time: datetime):
+    """Format datetime to string."""
+    return time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
 def _parse_value(name: str, value: Any, value_type: Any, default: Any = MISSING) -> Any:
     """Try to parse a value from raw (json) data and type annotations."""
     # ruff: noqa: PLR0911, PLR0912

--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -3,7 +3,9 @@
 import asyncio
 from asyncio.coroutines import iscoroutinefunction
 from collections.abc import Callable, Iterator
-from datetime import datetime
+
+# pylint: disable=no-name-in-module
+from datetime import datetime, UTC
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -276,7 +278,7 @@ class BaseResourcesController(Generic[CLIPResource]):
                     "last_event"
                 )
                 button_feature["button_report"]["updated"] = format_utc_timestamp(
-                    datetime.now()
+                    datetime.now(tz=UTC)
                 )
         if self.item_type == ResourceTypes.RELATIVE_ROTARY:
             relative_rotary_feature = evt_data.get("relative_rotary", {})
@@ -287,7 +289,7 @@ class BaseResourcesController(Generic[CLIPResource]):
                     "last_event"
                 )
                 relative_rotary_feature["rotary_report"]["updated"] = (
-                    format_utc_timestamp(datetime.now())
+                    format_utc_timestamp(datetime.now(tz=UTC))
                 )
 
     async def __handle_reconnect(self, full_state: list[dict]) -> None:

--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -3,6 +3,7 @@
 import asyncio
 from asyncio.coroutines import iscoroutinefunction
 from collections.abc import Callable, Iterator
+from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -15,6 +16,7 @@ from aiohue.util import (
     dataclass_from_dict,
     dataclass_to_dict,
     update_dataclass,
+    format_utc_timestamp,
 )
 from aiohue.v2.models.device import Device
 from aiohue.v2.models.resource import ResourceTypes
@@ -273,6 +275,9 @@ class BaseResourcesController(Generic[CLIPResource]):
                 button_feature["button_report"]["event"] = button_feature.get(
                     "last_event"
                 )
+                button_feature["button_report"]["updated"] = format_utc_timestamp(
+                    datetime.now()
+                )
         if self.item_type == ResourceTypes.RELATIVE_ROTARY:
             relative_rotary_feature = evt_data.get("relative_rotary", {})
             if relative_rotary_feature.get(
@@ -280,6 +285,9 @@ class BaseResourcesController(Generic[CLIPResource]):
             ) and not relative_rotary_feature.get("rotary_report"):
                 relative_rotary_feature["rotary_report"] = relative_rotary_feature.get(
                     "last_event"
+                )
+                relative_rotary_feature["rotary_report"]["updated"] = (
+                    format_utc_timestamp(datetime.now())
                 )
 
     async def __handle_reconnect(self, full_state: list[dict]) -> None:

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -129,25 +129,26 @@ def test_handle_last_event_backwards_compatibility_for_button():
     # pylint: disable=protected-access
     button_controller._handle_last_event_backwards_compatibility(evt_data)
 
-    assert (
-        evt_data.get("button", {}).get("button_report", {}).get("event")
-        == "initial_press"
-    )
+    button_report = evt_data.get("button", {}).get("button_report", {})
+    assert button_report.get("event") == "initial_press"
+    assert button_report.get("updated")
 
     evt_data = {
         "button": {
             "last_event": "initial_press",
-            "button_report": {"event": "short_release"},
+            "button_report": {
+                "event": "short_release",
+                "updated": "2024-08-24T16:27:00Z",
+            },
         }
     }
 
     # pylint: disable=protected-access
     button_controller._handle_last_event_backwards_compatibility(evt_data)
 
-    assert (
-        evt_data.get("button", {}).get("button_report", {}).get("event")
-        == "short_release"
-    )
+    button_report = evt_data.get("button", {}).get("button_report", {})
+    assert button_report.get("event") == "short_release"
+    assert button_report.get("updated") == "2024-08-24T16:27:00Z"
 
     evt_data = {"button": {}}
 
@@ -174,13 +175,12 @@ def test_handle_last_event_backwards_compatibility_for_relative_rotary():
     # pylint: disable=protected-access
     rotary_controller._handle_last_event_backwards_compatibility(evt_data)
 
-    assert (
-        evt_data.get("relative_rotary", {}).get("rotary_report", {}).get("action")
-        == "start"
-    )
-    assert evt_data.get("relative_rotary", {}).get("rotary_report", {}).get(
-        "rotation"
-    ) == evt_data.get("relative_rotary", {}).get("last_event", {}).get("rotation")
+    rotary_report = evt_data.get("relative_rotary", {}).get("rotary_report", {})
+    assert rotary_report.get("action") == "start"
+    assert rotary_report.get("rotation") == evt_data.get("relative_rotary", {}).get(
+        "last_event", {}
+    ).get("rotation")
+    assert rotary_report.get("updated")
 
     evt_data = {
         "relative_rotary": {
@@ -195,6 +195,7 @@ def test_handle_last_event_backwards_compatibility_for_relative_rotary():
                     "steps": 1,
                     "duration": 800,
                 },
+                "updated": "2024-08-24T16:27:00Z",
             },
         }
     }
@@ -202,31 +203,12 @@ def test_handle_last_event_backwards_compatibility_for_relative_rotary():
     # pylint: disable=protected-access
     rotary_controller._handle_last_event_backwards_compatibility(evt_data)
 
-    assert (
-        evt_data.get("relative_rotary", {}).get("rotary_report", {}).get("action")
-        == "repeat"
-    )
-    assert (
-        evt_data.get("relative_rotary", {})
-        .get("rotary_report", {})
-        .get("rotation", {})
-        .get("direction")
-        == "counter_clock_wise"
-    )
-    assert (
-        evt_data.get("relative_rotary", {})
-        .get("rotary_report", {})
-        .get("rotation", {})
-        .get("steps")
-        == 1
-    )
-    assert (
-        evt_data.get("relative_rotary", {})
-        .get("rotary_report", {})
-        .get("rotation", {})
-        .get("duration")
-        == 800
-    )
+    rotary_report = evt_data.get("relative_rotary", {}).get("rotary_report", {})
+    assert rotary_report.get("action") == "repeat"
+    assert rotary_report.get("rotation", {}).get("direction") == "counter_clock_wise"
+    assert rotary_report.get("rotation", {}).get("steps") == 1
+    assert rotary_report.get("rotation", {}).get("duration") == 800
+    assert rotary_report.get("updated") == "2024-08-24T16:27:00Z"
 
     evt_data = {"relative_rotary": {}}
 

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -6,7 +6,6 @@ from aiohue.v2.controllers.sensors import ButtonController, RelativeRotaryContro
 
 def test_handle_last_event_backwards_compatibility_for_button():
     """Test backwards compatibility handling for last_event in button."""
-
     bridge = HueBridgeV2("127.0.0.1", "fake")
     button_controller = ButtonController(bridge)
 
@@ -45,7 +44,6 @@ def test_handle_last_event_backwards_compatibility_for_button():
 
 def test_handle_last_event_backwards_compatibility_for_relative_rotary():
     """Test backwards compatibility handling for last_event in relative_rotary."""
-
     bridge = HueBridgeV2("127.0.0.1", "fake")
     rotary_controller = RelativeRotaryController(bridge)
 

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -8,7 +8,7 @@ from aiohue import HueBridgeV2
 from aiohue.v2 import EventType
 from aiohue.v2.controllers.base import BaseResourcesController
 from aiohue.v2.controllers.sensors import ButtonController, RelativeRotaryController
-from aiohue.v2.models.resource import ResourceIdentifier, ResourceTypes
+from aiohue.v2.models.resource import ResourceTypes
 
 
 @dataclass
@@ -18,7 +18,6 @@ class MockData:
     id: str
     type: ResourceTypes = ResourceTypes.UNKNOWN
 
-    owner: ResourceIdentifier | None = None
     id_v1: str | None = None
 
 
@@ -38,13 +37,11 @@ async def test_handle_event():
     controller.subscribe(callback)
 
     resource_id = str(uuid4())
-    device_id = str(uuid4())
+    other_id = str(uuid4())
 
     evt_data = {
         "id": resource_id,
-        "type": "unknown",
         "id_v1": "mock/1",
-        "owner": {"rid": device_id, "rtype": "device"},
     }
 
     # Create a new resource
@@ -55,9 +52,8 @@ async def test_handle_event():
         id=resource_id,
         type=ResourceTypes.UNKNOWN,
         id_v1="mock/1",
-        owner=ResourceIdentifier(rid=device_id, rtype=ResourceTypes.DEVICE),
     )
-    callback.assert_called_with(EventType.RESOURCE_ADDED, cur_data)
+    callback.assert_called_once_with(EventType.RESOURCE_ADDED, cur_data)
     callback.reset_mock()
 
     evt_data = {
@@ -73,13 +69,12 @@ async def test_handle_event():
         id=resource_id,
         type=ResourceTypes.UNKNOWN,
         id_v1="mock/2",
-        owner=ResourceIdentifier(rid=device_id, rtype=ResourceTypes.DEVICE),
     )
-    callback.assert_called_with(EventType.RESOURCE_UPDATED, cur_data)
+    callback.assert_called_once_with(EventType.RESOURCE_UPDATED, cur_data)
     callback.reset_mock()
 
     evt_data = {
-        "id": device_id,
+        "id": other_id,
         "id_v1": "mock/1",
     }
 
@@ -102,9 +97,8 @@ async def test_handle_event():
         id=resource_id,
         type=ResourceTypes.UNKNOWN,
         id_v1="mock/2",
-        owner=ResourceIdentifier(rid=device_id, rtype=ResourceTypes.DEVICE),
     )
-    callback.assert_called_with(EventType.RESOURCE_DELETED, cur_data)
+    callback.assert_called_once_with(EventType.RESOURCE_DELETED, cur_data)
     callback.reset_mock()
 
     evt_data = {

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -1,0 +1,109 @@
+from aiohue import HueBridgeV2
+from aiohue.v2.controllers.sensors import ButtonController, RelativeRotaryController
+
+
+def test_handle_last_event_backwards_compatibility_for_button():
+    evt_data = {"button": {"last_event": "initial_press"}}
+
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    button_controller = ButtonController(bridge)
+    button_controller._handle_last_event_backwards_compatibility(evt_data)
+
+    assert (
+        evt_data.get("button", {}).get("button_report", {}).get("event")
+        == "initial_press"
+    )
+
+    evt_data = {
+        "button": {
+            "last_event": "initial_press",
+            "button_report": {"event": "short_release"},
+        }
+    }
+
+    button_controller._handle_last_event_backwards_compatibility(evt_data)
+
+    assert (
+        evt_data.get("button", {}).get("button_report", {}).get("event")
+        == "short_release"
+    )
+
+    evt_data = {"button": {}}
+
+    button_controller._handle_last_event_backwards_compatibility(evt_data)
+
+    assert evt_data.get("button", {}).get("button_report") is None
+
+
+def test_handle_last_event_backwards_compatibility_for_relative_rotary():
+    evt_data = {
+        "relative_rotary": {
+            "last_event": {
+                "action": "start",
+                "rotation": {"direction": "clock_wise", "steps": 1, "duration": 800},
+            }
+        }
+    }
+
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    rotary_controller = RelativeRotaryController(bridge)
+    rotary_controller._handle_last_event_backwards_compatibility(evt_data)
+
+    assert (
+        evt_data.get("relative_rotary", {}).get("rotary_report", {}).get("action")
+        == "start"
+    )
+    assert evt_data.get("relative_rotary", {}).get("rotary_report", {}).get(
+        "rotation"
+    ) == evt_data.get("relative_rotary", {}).get("last_event", {}).get("rotation")
+
+    evt_data = {
+        "relative_rotary": {
+            "last_event": {
+                "action": "start",
+                "rotation": {"direction": "clock_wise", "steps": 1, "duration": 800},
+            },
+            "rotary_report": {
+                "action": "repeat",
+                "rotation": {
+                    "direction": "counter_clock_wise",
+                    "steps": 1,
+                    "duration": 800,
+                },
+            },
+        }
+    }
+
+    rotary_controller._handle_last_event_backwards_compatibility(evt_data)
+
+    assert (
+        evt_data.get("relative_rotary", {}).get("rotary_report", {}).get("action")
+        == "repeat"
+    )
+    assert (
+        evt_data.get("relative_rotary", {})
+        .get("rotary_report", {})
+        .get("rotation", {})
+        .get("direction")
+        == "counter_clock_wise"
+    )
+    assert (
+        evt_data.get("relative_rotary", {})
+        .get("rotary_report", {})
+        .get("rotation", {})
+        .get("steps")
+        == 1
+    )
+    assert (
+        evt_data.get("relative_rotary", {})
+        .get("rotary_report", {})
+        .get("rotation", {})
+        .get("duration")
+        == 800
+    )
+
+    evt_data = {"relative_rotary": {}}
+
+    rotary_controller._handle_last_event_backwards_compatibility(evt_data)
+
+    assert evt_data.get("relative_rotary", {}).get("rotary_report") is None

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -1,7 +1,122 @@
 """Test base controller functions."""
 
+from dataclasses import dataclass
+from unittest.mock import Mock
+from uuid import uuid4
+
 from aiohue import HueBridgeV2
+from aiohue.v2 import EventType
+from aiohue.v2.controllers.base import BaseResourcesController
 from aiohue.v2.controllers.sensors import ButtonController, RelativeRotaryController
+from aiohue.v2.models.resource import ResourceIdentifier, ResourceTypes
+
+
+@dataclass
+class MockData:
+    """Mock data resource type."""
+
+    id: str
+    type: ResourceTypes = ResourceTypes.UNKNOWN
+
+    owner: ResourceIdentifier | None = None
+    id_v1: str | None = None
+
+
+class MockController(BaseResourcesController[type[MockData]]):
+    """Controller for mock data resource."""
+
+    item_type = ResourceTypes.UNKNOWN
+    item_cls = MockData
+    allow_parser_error = False
+
+
+async def test_handle_event():
+    """Test handling of events."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    controller = MockController(bridge)
+    callback = Mock(return_value=None)
+    controller.subscribe(callback)
+
+    resource_id = str(uuid4())
+    device_id = str(uuid4())
+
+    evt_data = {
+        "id": resource_id,
+        "type": "unknown",
+        "id_v1": "mock/1",
+        "owner": {"rid": device_id, "rtype": "device"},
+    }
+
+    # Create a new resource
+    # pylint: disable=protected-access
+    await controller._handle_event(EventType.RESOURCE_ADDED, evt_data, False)
+
+    cur_data = MockData(
+        id=resource_id,
+        type=ResourceTypes.UNKNOWN,
+        id_v1="mock/1",
+        owner=ResourceIdentifier(rid=device_id, rtype=ResourceTypes.DEVICE),
+    )
+    callback.assert_called_with(EventType.RESOURCE_ADDED, cur_data)
+    callback.reset_mock()
+
+    evt_data = {
+        "id": resource_id,
+        "id_v1": "mock/2",
+    }
+
+    # Update of a single property of an existing resource
+    # pylint: disable=protected-access
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+
+    cur_data = MockData(
+        id=resource_id,
+        type=ResourceTypes.UNKNOWN,
+        id_v1="mock/2",
+        owner=ResourceIdentifier(rid=device_id, rtype=ResourceTypes.DEVICE),
+    )
+    callback.assert_called_with(EventType.RESOURCE_UPDATED, cur_data)
+    callback.reset_mock()
+
+    evt_data = {
+        "id": device_id,
+        "id_v1": "mock/1",
+    }
+
+    # Update of a single property of a non-existing resource
+    # pylint: disable=protected-access
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+
+    callback.assert_not_called()
+    callback.reset_mock()
+
+    evt_data = {
+        "id": resource_id,
+    }
+
+    # Remove of existing resource
+    # pylint: disable=protected-access
+    await controller._handle_event(EventType.RESOURCE_DELETED, evt_data, False)
+
+    cur_data = MockData(
+        id=resource_id,
+        type=ResourceTypes.UNKNOWN,
+        id_v1="mock/2",
+        owner=ResourceIdentifier(rid=device_id, rtype=ResourceTypes.DEVICE),
+    )
+    callback.assert_called_with(EventType.RESOURCE_DELETED, cur_data)
+    callback.reset_mock()
+
+    evt_data = {
+        "id": resource_id,
+        "id_v1": "mock/2",
+    }
+
+    # Update of an already removed resource
+    # pylint: disable=protected-access
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+
+    callback.assert_not_called()
 
 
 def test_handle_last_event_backwards_compatibility_for_button():

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -1,12 +1,18 @@
+"""Test base controller functions."""
+
 from aiohue import HueBridgeV2
 from aiohue.v2.controllers.sensors import ButtonController, RelativeRotaryController
 
 
 def test_handle_last_event_backwards_compatibility_for_button():
-    evt_data = {"button": {"last_event": "initial_press"}}
+    """Test backwards compatibility handling for last_event in button"""
 
     bridge = HueBridgeV2("127.0.0.1", "fake")
     button_controller = ButtonController(bridge)
+
+    evt_data = {"button": {"last_event": "initial_press"}}
+
+    # pylint: disable=protected-access
     button_controller._handle_last_event_backwards_compatibility(evt_data)
 
     assert (
@@ -21,6 +27,7 @@ def test_handle_last_event_backwards_compatibility_for_button():
         }
     }
 
+    # pylint: disable=protected-access
     button_controller._handle_last_event_backwards_compatibility(evt_data)
 
     assert (
@@ -30,12 +37,18 @@ def test_handle_last_event_backwards_compatibility_for_button():
 
     evt_data = {"button": {}}
 
+    # pylint: disable=protected-access
     button_controller._handle_last_event_backwards_compatibility(evt_data)
 
     assert evt_data.get("button", {}).get("button_report") is None
 
 
 def test_handle_last_event_backwards_compatibility_for_relative_rotary():
+    """Test backwards compatibility handling for last_event in relative_rotary"""
+
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    rotary_controller = RelativeRotaryController(bridge)
+
     evt_data = {
         "relative_rotary": {
             "last_event": {
@@ -45,8 +58,7 @@ def test_handle_last_event_backwards_compatibility_for_relative_rotary():
         }
     }
 
-    bridge = HueBridgeV2("127.0.0.1", "fake")
-    rotary_controller = RelativeRotaryController(bridge)
+    # pylint: disable=protected-access
     rotary_controller._handle_last_event_backwards_compatibility(evt_data)
 
     assert (
@@ -74,6 +86,7 @@ def test_handle_last_event_backwards_compatibility_for_relative_rotary():
         }
     }
 
+    # pylint: disable=protected-access
     rotary_controller._handle_last_event_backwards_compatibility(evt_data)
 
     assert (
@@ -104,6 +117,7 @@ def test_handle_last_event_backwards_compatibility_for_relative_rotary():
 
     evt_data = {"relative_rotary": {}}
 
+    # pylint: disable=protected-access
     rotary_controller._handle_last_event_backwards_compatibility(evt_data)
 
     assert evt_data.get("relative_rotary", {}).get("rotary_report") is None

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -46,7 +46,7 @@ async def test_handle_event():
 
     # Create a new resource
     # pylint: disable=protected-access
-    await controller._handle_event(EventType.RESOURCE_ADDED, evt_data, False)
+    await controller._handle_event(EventType.RESOURCE_ADDED, evt_data)
 
     cur_data = MockData(
         id=resource_id,
@@ -63,7 +63,7 @@ async def test_handle_event():
 
     # Update of a single property of an existing resource
     # pylint: disable=protected-access
-    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data)
 
     cur_data = MockData(
         id=resource_id,
@@ -80,7 +80,7 @@ async def test_handle_event():
 
     # Update of a single property of a non-existing resource
     # pylint: disable=protected-access
-    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data)
 
     callback.assert_not_called()
     callback.reset_mock()
@@ -91,7 +91,7 @@ async def test_handle_event():
 
     # Remove of existing resource
     # pylint: disable=protected-access
-    await controller._handle_event(EventType.RESOURCE_DELETED, evt_data, False)
+    await controller._handle_event(EventType.RESOURCE_DELETED, evt_data)
 
     cur_data = MockData(
         id=resource_id,
@@ -108,7 +108,7 @@ async def test_handle_event():
 
     # Update of an already removed resource
     # pylint: disable=protected-access
-    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data)
 
     callback.assert_not_called()
 

--- a/tests/v2/test_base_resource_controller.py
+++ b/tests/v2/test_base_resource_controller.py
@@ -5,7 +5,7 @@ from aiohue.v2.controllers.sensors import ButtonController, RelativeRotaryContro
 
 
 def test_handle_last_event_backwards_compatibility_for_button():
-    """Test backwards compatibility handling for last_event in button"""
+    """Test backwards compatibility handling for last_event in button."""
 
     bridge = HueBridgeV2("127.0.0.1", "fake")
     button_controller = ButtonController(bridge)
@@ -44,7 +44,7 @@ def test_handle_last_event_backwards_compatibility_for_button():
 
 
 def test_handle_last_event_backwards_compatibility_for_relative_rotary():
-    """Test backwards compatibility handling for last_event in relative_rotary"""
+    """Test backwards compatibility handling for last_event in relative_rotary."""
 
     bridge = HueBridgeV2("127.0.0.1", "fake")
     rotary_controller = RelativeRotaryController(bridge)

--- a/tests/v2/test_button_controller.py
+++ b/tests/v2/test_button_controller.py
@@ -34,7 +34,7 @@ async def create_button(
 
     # Create a new resource
     # pylint: disable=protected-access
-    await controller._handle_event(EventType.RESOURCE_ADDED, evt_data, False)
+    await controller._handle_event(EventType.RESOURCE_ADDED, evt_data)
 
     callback.assert_called_once()
     callback.reset_mock()
@@ -59,7 +59,7 @@ async def create_device(
     }
 
     # pylint: disable=protected-access
-    await bridge.devices._handle_event(EventType.RESOURCE_ADDED, evt_data, False)
+    await bridge.devices._handle_event(EventType.RESOURCE_ADDED, evt_data)
 
 
 def generate_button_event_data(button_id: str, event: str, device_id: str):
@@ -74,6 +74,17 @@ def generate_button_event_data(button_id: str, event: str, device_id: str):
         },
         "owner": {"rid": device_id, "rtype": ResourceTypes.DEVICE},
     }
+
+
+async def handle_button_event(
+    controller: ButtonController, button_id: str, event: str, device_id: str
+):
+    """Handle button event."""
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, event, device_id),
+    )
 
 
 class CopyingMock(Mock):
@@ -98,12 +109,7 @@ async def test_handle_events():
     await create_button(controller, callback, button_id, device_id)
 
     # Button event
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "initial_press", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "initial_press", device_id)
 
     callback.assert_called_once()
     assert (
@@ -119,7 +125,7 @@ async def test_handle_events():
 
     # Absent button report is dropped
     # pylint: disable=protected-access
-    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data)
 
     callback.assert_not_called()
     callback.reset_mock()
@@ -139,22 +145,12 @@ async def test_handle_events_button_workaround_short_release():
     await create_button(controller, callback, button_id, device_id)
 
     # Button event: initial_press
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "initial_press", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "initial_press", device_id)
 
     await asyncio.sleep(1.2)
 
     # Button event: short_release
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "short_release", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "short_release", device_id)
 
     callback.assert_called()
     assert callback.call_count == 2
@@ -182,22 +178,12 @@ async def test_handle_events_button_workaround_repeats():
     await create_button(controller, callback, button_id, device_id)
 
     # Button event: initial_press
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "initial_press", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "initial_press", device_id)
 
     await asyncio.sleep(2.2)
 
     # Button event: short_release
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "short_release", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "short_release", device_id)
 
     callback.assert_called()
     assert callback.call_count == 4
@@ -233,12 +219,7 @@ async def test_handle_events_button_workaround_long_release():
     await create_button(controller, callback, button_id, device_id)
 
     # Button event: initial_press
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "initial_press", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "initial_press", device_id)
 
     await asyncio.sleep(12.7)
 
@@ -268,22 +249,12 @@ async def test_handle_events_button_workaround_interrupt():
     await create_button(controller, callback, button2_id, device2_id)
 
     # Button event: initial_press
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button1_id, "initial_press", device1_id),
-        False,
-    )
+    await handle_button_event(controller, button1_id, "initial_press", device1_id)
 
     await asyncio.sleep(2.2)
 
     # Button event: initial_press
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button2_id, "initial_press", device2_id),
-        False,
-    )
+    await handle_button_event(controller, button2_id, "initial_press", device2_id)
 
     callback.assert_called()
     assert callback.call_count == 4
@@ -320,22 +291,12 @@ async def test_handle_events_button_non_workaround_device():
     await create_button(controller, callback, button_id, device_id)
 
     # Button event: initial_press
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "initial_press", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "initial_press", device_id)
 
     await asyncio.sleep(2.2)
 
     # Button event: short_release
-    # pylint: disable=protected-access
-    await controller._handle_event(
-        EventType.RESOURCE_UPDATED,
-        generate_button_event_data(button_id, "short_release", device_id),
-        False,
-    )
+    await handle_button_event(controller, button_id, "short_release", device_id)
 
     callback.assert_called()
     assert callback.call_count == 2

--- a/tests/v2/test_button_controller.py
+++ b/tests/v2/test_button_controller.py
@@ -1,0 +1,349 @@
+"""Test button controller functions."""
+
+import asyncio
+from copy import deepcopy
+from unittest.mock import Mock
+from uuid import uuid4
+
+from aiohue import HueBridgeV2
+from aiohue.v2 import EventType
+from aiohue.v2.controllers.sensors import ButtonController
+from aiohue.v2.models.button import ButtonEvent
+from aiohue.v2.models.resource import ResourceTypes
+
+
+async def create_button(
+    controller: ButtonController, callback: Mock, button_id: str, device_id: str
+):
+    """Create a button resource."""
+    evt_data = {
+        "id": button_id,
+        "metadata": {"control_id": 1},
+        "button": {
+            "event_values": [
+                "initial_press",
+                "repeat",
+                "short_release",
+                "long_release",
+                "long_press",
+            ],
+            "repeat_interval": 800,
+        },
+        "owner": {"rid": device_id, "rtype": ResourceTypes.DEVICE},
+    }
+
+    # Create a new resource
+    # pylint: disable=protected-access
+    await controller._handle_event(EventType.RESOURCE_ADDED, evt_data, False)
+
+    callback.assert_called_once()
+    callback.reset_mock()
+
+
+async def create_device(
+    bridge: HueBridgeV2, device_id: str, model_id: str, button_id: str
+):
+    """Create a device resource."""
+    evt_data = {
+        "id": device_id,
+        "services": [{"rid": button_id, "rtype": "button"}],
+        "product_data": {
+            "model_id": model_id,
+            "manufacturer_name": "Signify",
+            "product_name": "Hue Light",
+            "product_archetype": "classic_bulb",
+            "certified": True,
+            "software_version": "1.0.0",
+        },
+        "metadata": {"archetype": "classic_bulb", "name": "Kitchen"},
+    }
+
+    # pylint: disable=protected-access
+    await bridge.devices._handle_event(EventType.RESOURCE_ADDED, evt_data, False)
+
+
+def generate_button_event_data(button_id: str, event: str, device_id: str):
+    """Generate button event data."""
+    return {
+        "id": button_id,
+        "button": {
+            "button_report": {
+                "event": event,
+                "updated": "2024-08-24T16:24:00.0Z",
+            }
+        },
+        "owner": {"rid": device_id, "rtype": ResourceTypes.DEVICE},
+    }
+
+
+class CopyingMock(Mock):
+    """Mock that deep copies its arguments."""
+
+    def __call__(self, *args, **kwargs):
+        args = deepcopy(args)
+        kwargs = deepcopy(kwargs)
+        return super().__call__(*args, **kwargs)
+
+
+async def test_handle_events():
+    """Test handling of events."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    controller = ButtonController(bridge)
+    callback = CopyingMock(return_value=None)
+    controller.subscribe(callback)
+
+    button_id = str(uuid4())
+    device_id = str(uuid4())
+
+    await create_button(controller, callback, button_id, device_id)
+
+    # Button event
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "initial_press", device_id),
+        False,
+    )
+
+    callback.assert_called_once()
+    assert (
+        callback.call_args.args[1].button.button_report.event
+        == ButtonEvent.INITIAL_PRESS
+    )
+    callback.reset_mock()
+
+    evt_data = {
+        "id": button_id,
+        "owner": {"rid": device_id, "rtype": ResourceTypes.DEVICE},
+    }
+
+    # Absent button report is dropped
+    # pylint: disable=protected-access
+    await controller._handle_event(EventType.RESOURCE_UPDATED, evt_data, False)
+
+    callback.assert_not_called()
+    callback.reset_mock()
+
+
+async def test_handle_events_button_workaround_short_release():
+    """Test handling of events for device requiring button workaround."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    controller = ButtonController(bridge)
+    callback = CopyingMock(return_value=None)
+    controller.subscribe(callback)
+
+    button_id = str(uuid4())
+    device_id = str(uuid4())
+
+    await create_device(bridge, device_id, "FOHSWITCH", button_id)
+    await create_button(controller, callback, button_id, device_id)
+
+    # Button event: initial_press
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "initial_press", device_id),
+        False,
+    )
+
+    await asyncio.sleep(1.2)
+
+    # Button event: short_release
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "short_release", device_id),
+        False,
+    )
+
+    callback.assert_called()
+    assert callback.call_count == 2
+    assert (
+        callback.call_args_list[0].args[1].button.button_report.event
+        == ButtonEvent.INITIAL_PRESS
+    )
+    assert (
+        callback.call_args_list[1].args[1].button.button_report.event
+        == ButtonEvent.SHORT_RELEASE
+    )
+
+
+async def test_handle_events_button_workaround_repeats():
+    """Test handling of events for device requiring button workaround."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    controller = ButtonController(bridge)
+    callback = CopyingMock(return_value=None)
+    controller.subscribe(callback)
+
+    button_id = str(uuid4())
+    device_id = str(uuid4())
+
+    await create_device(bridge, device_id, "FOHSWITCH", button_id)
+    await create_button(controller, callback, button_id, device_id)
+
+    # Button event: initial_press
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "initial_press", device_id),
+        False,
+    )
+
+    await asyncio.sleep(2.2)
+
+    # Button event: short_release
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "short_release", device_id),
+        False,
+    )
+
+    callback.assert_called()
+    assert callback.call_count == 4
+    assert (
+        callback.call_args_list[0].args[1].button.button_report.event
+        == ButtonEvent.INITIAL_PRESS
+    )
+    assert (
+        callback.call_args_list[1].args[1].button.button_report.event
+        == ButtonEvent.REPEAT
+    )
+    assert (
+        callback.call_args_list[2].args[1].button.button_report.event
+        == ButtonEvent.REPEAT
+    )
+    assert (
+        callback.call_args_list[3].args[1].button.button_report.event
+        == ButtonEvent.SHORT_RELEASE
+    )
+
+
+async def test_handle_events_button_workaround_long_release():
+    """Test handling of events for device requiring button workaround."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    controller = ButtonController(bridge)
+    callback = CopyingMock(return_value=None)
+    controller.subscribe(callback)
+
+    button_id = str(uuid4())
+    device_id = str(uuid4())
+
+    await create_device(bridge, device_id, "FOHSWITCH", button_id)
+    await create_button(controller, callback, button_id, device_id)
+
+    # Button event: initial_press
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "initial_press", device_id),
+        False,
+    )
+
+    await asyncio.sleep(12.7)
+
+    callback.assert_called()
+    assert callback.call_count == 23
+    assert (
+        callback.call_args_list[22].args[1].button.button_report.event
+        == ButtonEvent.LONG_RELEASE
+    )
+
+
+async def test_handle_events_button_workaround_interrupt():
+    """Test handling of events for device requiring button workaround."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    controller = ButtonController(bridge)
+    callback = CopyingMock(return_value=None)
+    controller.subscribe(callback)
+
+    button1_id = str(uuid4())
+    button2_id = str(uuid4())
+    device1_id = str(uuid4())
+    device2_id = str(uuid4())
+
+    await create_device(bridge, device1_id, "FOHSWITCH", button1_id)
+    await create_device(bridge, device2_id, "ZGPSWITCH", button2_id)
+    await create_button(controller, callback, button1_id, device1_id)
+    await create_button(controller, callback, button2_id, device2_id)
+
+    # Button event: initial_press
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button1_id, "initial_press", device1_id),
+        False,
+    )
+
+    await asyncio.sleep(2.2)
+
+    # Button event: initial_press
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button2_id, "initial_press", device2_id),
+        False,
+    )
+
+    callback.assert_called()
+    assert callback.call_count == 4
+    assert (
+        callback.call_args_list[0].args[1].button.button_report.event
+        == ButtonEvent.INITIAL_PRESS
+    )
+    assert (
+        callback.call_args_list[1].args[1].button.button_report.event
+        == ButtonEvent.REPEAT
+    )
+    assert (
+        callback.call_args_list[2].args[1].button.button_report.event
+        == ButtonEvent.REPEAT
+    )
+    assert callback.call_args_list[3].args[1].id == button2_id
+    assert (
+        callback.call_args_list[3].args[1].button.button_report.event
+        == ButtonEvent.INITIAL_PRESS
+    )
+
+
+async def test_handle_events_button_non_workaround_device():
+    """Test handling of events for device requiring button workaround."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    controller = ButtonController(bridge)
+    callback = CopyingMock(return_value=None)
+    controller.subscribe(callback)
+
+    button_id = str(uuid4())
+    device_id = str(uuid4())
+
+    await create_device(bridge, device_id, "ZGPSWITCH", button_id)
+    await create_button(controller, callback, button_id, device_id)
+
+    # Button event: initial_press
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "initial_press", device_id),
+        False,
+    )
+
+    await asyncio.sleep(2.2)
+
+    # Button event: short_release
+    # pylint: disable=protected-access
+    await controller._handle_event(
+        EventType.RESOURCE_UPDATED,
+        generate_button_event_data(button_id, "short_release", device_id),
+        False,
+    )
+
+    callback.assert_called()
+    assert callback.call_count == 2
+    assert (
+        callback.call_args_list[0].args[1].button.button_report.event
+        == ButtonEvent.INITIAL_PRESS
+    )
+    assert (
+        callback.call_args_list[1].args[1].button.button_report.event
+        == ButtonEvent.SHORT_RELEASE
+    )


### PR DESCRIPTION
Added code to handle the case where the bridge only emits the deprecated `last_event` property and not `button_report` (or `relative_rotary`). Also created a test for it.

I do wonder whether this code has to move to the `ButtonController` (and `RelativeRotaryController`) class before `_handle_event` on the base class is called, including the code that drops update-events that do not have a report. But I'm not sure if any of the code that is after `super()._handle_event(...)` is still relevant even if we decided not to inject the event/new resource upstream.