### PR TITLE
Add dimming_delta support

### DIFF
--- a/aiohue/v2/controllers/groups.py
+++ b/aiohue/v2/controllers/groups.py
@@ -9,7 +9,9 @@ from aiohue.v2.models.feature import (
     ColorFeaturePut,
     ColorPoint,
     ColorTemperatureFeaturePut,
+    DeltaAction,
     DimmingFeaturePut,
+    DimmingDeltaFeaturePut,
     DynamicsFeaturePut,
     OnFeature,
 )
@@ -140,6 +142,29 @@ class GroupedLightController(BaseResourcesController[type[GroupedLight]]):
         if alert is not None:
             update_obj.alert = AlertFeaturePut(action=alert)
 
+        await self.update(id, update_obj)
+
+    async def set_dimming_delta(
+        self, id: str, brightness_delta: float | None = None
+    ) -> None:
+        """
+        Set brightness_delta value and action via DimmingDeltaFeature.
+
+        The action to be send depends on brightness_delta value:
+         None: STOP (this immediately stops any dimming transition)
+         > 0: UP,
+         < 0: DOWN
+        """
+        if brightness_delta in (None, 0):
+            dimming_delta = DimmingDeltaFeaturePut(action=DeltaAction.STOP)
+        else:
+            dimming_delta = DimmingDeltaFeaturePut(
+                action=DeltaAction.UP if brightness_delta > 0 else DeltaAction.DOWN,
+                brightness_delta=abs(brightness_delta),
+            )
+
+        update_obj = GroupedLightPut()
+        update_obj.dimming_delta = dimming_delta
         await self.update(id, update_obj)
 
 

--- a/aiohue/v2/controllers/lights.py
+++ b/aiohue/v2/controllers/lights.py
@@ -6,7 +6,9 @@ from aiohue.v2.models.feature import (
     ColorFeaturePut,
     ColorPoint,
     ColorTemperatureFeaturePut,
+    DeltaAction,
     DimmingFeaturePut,
+    DimmingDeltaFeaturePut,
     DynamicsFeaturePut,
     EffectsFeaturePut,
     EffectStatus,
@@ -99,4 +101,27 @@ class LightsController(BaseResourcesController[type[Light]]):
             )
         elif effect is not None:
             update_obj.effects = EffectsFeaturePut(effect=effect)
+        await self.update(id, update_obj)
+
+    async def set_dimming_delta(
+        self, id: str, brightness_delta: float | None = None
+    ) -> None:
+        """
+        Set brightness_delta value and action via DimmingDeltaFeature.
+
+        The action to be send depends on brightness_delta value:
+         None: STOP (this immediately stops any dimming transition)
+         > 0: UP,
+         < 0: DOWN
+        """
+        if brightness_delta in (None, 0):
+            dimming_delta = DimmingDeltaFeaturePut(action=DeltaAction.STOP)
+        else:
+            dimming_delta = DimmingDeltaFeaturePut(
+                action=DeltaAction.UP if brightness_delta > 0 else DeltaAction.DOWN,
+                brightness_delta=abs(brightness_delta),
+            )
+
+        update_obj = LightPut()
+        update_obj.dimming_delta = dimming_delta
         await self.update(id, update_obj)


### PR DESCRIPTION
This method sets the brightness_delta value and its action based on the
value to up/down/stop. This can be useful if someone wants to dim a light to
the max/min value within a dedicated transition time but stop the
transition  when for instance a btn was released.

resolves https://github.com/home-assistant-libs/aiohue/issues/420