### PR TITLE
🐛 Makes ResourceTypes serialisable

### DIFF
--- a/aiohue/v2/models/resource.py
+++ b/aiohue/v2/models/resource.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 
-class ResourceTypes(Enum):
+class ResourceTypes(str, Enum):
     """
     Type of the supported resources.
 


### PR DESCRIPTION
For API calls with ResourceTypes as arguments, this Enum must be converted to string.

PR not tested as I'm on my phone 

Fix #407