### PR TITLE
Replace deprecated asyncio.iscoroutinefunction

### DIFF
--- a/aiohue/v2/controllers/base.py
+++ b/aiohue/v2/controllers/base.py
@@ -1,8 +1,8 @@
 """Base controller for HUE resources as retrieved from the Hue bridge."""
 
 import asyncio
-from asyncio.coroutines import iscoroutinefunction
 from collections.abc import Callable, Iterator
+from inspect import iscoroutinefunction
 
 from typing import (
     TYPE_CHECKING,

--- a/aiohue/v2/controllers/events.py
+++ b/aiohue/v2/controllers/events.py
@@ -1,10 +1,10 @@
 """Handle connecting to the HUE Eventstream and distribute events."""
 
 import asyncio
-from asyncio.coroutines import iscoroutinefunction
 from collections import deque
 from collections.abc import Callable
 from enum import Enum
+from inspect import iscoroutinefunction
 import json
 import random
 import string


### PR DESCRIPTION
Python 3.14 will deprecated `asyncio.iscoroutinefunction` in favor of `inspect.iscoroutinefunction` which has been available for some time now.

https://docs.python.org/3.14/deprecations/pending-removal-in-3.16.html
https://docs.python.org/3.14/library/inspect.html#inspect.iscoroutinefunction