### PR TITLE
Add missing value to ConnectivityServiceStatus enum

### DIFF
--- a/aiohue/v2/models/zigbee_connectivity.py
+++ b/aiohue/v2/models/zigbee_connectivity.py
@@ -23,6 +23,7 @@ class ConnectivityServiceStatus(Enum):
     DISCONNECTED = "disconnected"
     CONNECTIVITY_ISSUE = "connectivity_issue"
     UNIDIRECTIONAL_INCOMING = "unidirectional_incoming"
+    PENDING_DISCOVERY = "pending_discovery"
 
 
 @dataclass


### PR DESCRIPTION
I noticed that the ConnectivityServiceStatus enum was missing a value `pending_dicsovery`.

See documentation on 
https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_zigbee_connectivity__id__get

<img width="803" height="87" alt="image" src="https://github.com/user-attachments/assets/057b0aea-22d2-4d60-a62f-2198b9d633c6" />
