### PR TITLE
Fix motion_area_configuration model compatibility with Hue Bridge Pro

### DIFF
--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -138,14 +138,16 @@ class MotionAreaConfigurationController(
             and isinstance(x, (ConvenienceAreaMotion, SecurityAreaMotion))
         ]
 
-    def get_group(self, id: str) -> Room | Zone:
+    def get_group(self, id: str) -> Room | Zone | None:
         """Return the group associated with this motion area configuration."""
         if id not in self._items:
             raise KeyError(f"Motion area configuration {id} not found")
-        group_id = self._items[id].group.rid
-        if group_id not in self._bridge.groups:
-            raise KeyError(f"Group {group_id} not found")
-        return self._bridge.groups[group_id]
+        group = self._items[id].group
+        if group is None:
+            return None
+        if group.rid not in self._bridge.groups:
+            raise KeyError(f"Group {group.rid} not found")
+        return self._bridge.groups[group.rid]
 
     async def set_enabled(self, id: str, enabled: bool) -> None:
         """Enable/Disable motion area configuration."""

--- a/aiohue/v2/models/convenience_area_motion.py
+++ b/aiohue/v2/models/convenience_area_motion.py
@@ -27,8 +27,10 @@ class ConvenienceAreaMotion:
     # enabled: required(boolean)
     # true when sensor is activated, false when deactivated
     enabled: bool
-    motion: MotionSensingFeature
-    sensitivity: MotionSensingFeatureSensitivity | None
+
+    # Absent on Hue Bridge Pro
+    motion: MotionSensingFeature | None = None
+    sensitivity: MotionSensingFeatureSensitivity | None = None
 
     id_v1: str | None = None
     type: ResourceTypes = ResourceTypes.CONVENIENCE_AREA_MOTION

--- a/aiohue/v2/models/motion_area_configuration.py
+++ b/aiohue/v2/models/motion_area_configuration.py
@@ -55,15 +55,23 @@ class MotionAreaConfiguration:
     Represent a (full) `MotionAreaConfiguration` resource when retrieved from the api.
 
     https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_motion_area_configuration_get
+
+    Note: Hue Bridge Pro returns a simplified schema with only `id`, `owner`, `enabled`,
+    and `type`. The remaining fields are only present on standard Hue Bridges.
     """
 
     id: str
-    name: str
-    group: ResourceIdentifier
-    participants: list[MotionAreaParticipant]
-    services: list[ResourceIdentifier]
-    health: MotionAreaHealth
     enabled: bool
+
+    # Present on Hue Bridge Pro
+    owner: ResourceIdentifier | None = None
+
+    # Present on standard Hue Bridge only
+    name: str | None = None
+    group: ResourceIdentifier | None = None
+    participants: list[MotionAreaParticipant] | None = None
+    services: list[ResourceIdentifier] | None = None
+    health: MotionAreaHealth | None = None
 
     id_v1: str | None = None
     type: ResourceTypes = ResourceTypes.MOTION_AREA_CONFIGURATION

--- a/aiohue/v2/models/security_area_motion.py
+++ b/aiohue/v2/models/security_area_motion.py
@@ -27,8 +27,10 @@ class SecurityAreaMotion:
     # enabled: required(boolean)
     # true when sensor is activated, false when deactivated
     enabled: bool
-    motion: MotionSensingFeature
-    sensitivity: MotionSensingFeatureSensitivity | None
+
+    # Absent on Hue Bridge Pro
+    motion: MotionSensingFeature | None = None
+    sensitivity: MotionSensingFeatureSensitivity | None = None
 
     id_v1: str | None = None
     type: ResourceTypes = ResourceTypes.SECURITY_AREA_MOTION


### PR DESCRIPTION
Follow-up to #546. Claude helped with understanding the codebase and with coding. This is my first PR to this project, and I'm not sure that this is the right approach.

I wanted to enable and disable MotionAware zones from Home Assistant and have the state reflected there. Currently this fails with a 400 Bad Request because the resources never load on Bridge Pro.

Changes:
- Make standard-Bridge-only fields optional (| None = None)
- Add owner as optional field (present on Bridge Pro)
- Update get_group() to handle None group

I used a simple Python script to test against a real Hue Bridge Pro and set_enabled() was able to toggle my MotionAware zones.

Related: home-assistant/core#153935, home-assistant/core#160393

A corresponding HA core change will be necessary as the switch platform currently creates toggles from behavior_instance only and has no motion_area_configuration support.