### PR TITLE
Add SceneActivityTracker to track active scenes per Hue group

### DIFF
--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -95,44 +95,54 @@ class SceneActivityTracker:
         """Apply scene state to group tracking. Returns True if state changed."""
         if not scene.id:
             return False
-        group_id = scene.group.rid
-        group_state = self._group_states[group_id]
-
+        group_state = self._group_states[scene.group.rid]
         if isinstance(scene, Scene):
-            if scene.status is None:
-                return False
-            if scene.status.active != SceneActiveStatus.INACTIVE:
-                group_state.active_scene_id = scene.id
-                group_state.active_scene_name = scene.metadata.name
-                group_state.active_scene_mode = scene.status.active.value
-                group_state.active_scene_last_recall = scene.status.last_recall
-                group_state.active_scene_speed = scene.speed
-                group_state.active_scene_brightness = next(
-                    (
-                        action.action.dimming.brightness
-                        for action in scene.actions
-                        if action.action.dimming is not None
-                    ),
-                    None,
-                )
-                return True
-            if group_state.active_scene_id == scene.id:
-                group_state.active_scene_id = None
-                group_state.active_scene_name = None
-                group_state.active_scene_mode = None
-                group_state.active_scene_last_recall = None
-                group_state.active_scene_speed = None
-                group_state.active_scene_brightness = None
-                return True
-            return False
-
+            return self._apply_regular_scene_update(scene, group_state)
         if isinstance(scene, SmartScene):
-            if scene.state == SmartSceneState.ACTIVE:
-                group_state.active_smart_scene_id = scene.id
-                group_state.active_smart_scene_name = scene.metadata.name
-                return True
-            if group_state.active_smart_scene_id == scene.id:
-                group_state.active_smart_scene_id = None
-                group_state.active_smart_scene_name = None
-                return True
+            return self._apply_smart_scene_update(scene, group_state)
+        return False
+
+    def _apply_regular_scene_update(
+        self, scene: Scene, group_state: GroupSceneState
+    ) -> bool:
+        """Update group state from a regular scene event. Returns True if changed."""
+        if scene.status is None:
+            return False
+        if scene.status.active != SceneActiveStatus.INACTIVE:
+            group_state.active_scene_id = scene.id
+            group_state.active_scene_name = scene.metadata.name
+            group_state.active_scene_mode = scene.status.active.value
+            group_state.active_scene_last_recall = scene.status.last_recall
+            group_state.active_scene_speed = scene.speed
+            group_state.active_scene_brightness = next(
+                (
+                    action.action.dimming.brightness
+                    for action in scene.actions
+                    if action.action.dimming is not None
+                ),
+                None,
+            )
+            return True
+        if group_state.active_scene_id == scene.id:
+            group_state.active_scene_id = None
+            group_state.active_scene_name = None
+            group_state.active_scene_mode = None
+            group_state.active_scene_last_recall = None
+            group_state.active_scene_speed = None
+            group_state.active_scene_brightness = None
+            return True
+        return False
+
+    def _apply_smart_scene_update(
+        self, scene: SmartScene, group_state: GroupSceneState
+    ) -> bool:
+        """Update group state from a smart scene event. Returns True if changed."""
+        if scene.state == SmartSceneState.ACTIVE:
+            group_state.active_smart_scene_id = scene.id
+            group_state.active_smart_scene_name = scene.metadata.name
+            return True
+        if group_state.active_smart_scene_id == scene.id:
+            group_state.active_smart_scene_id = None
+            group_state.active_smart_scene_name = None
+            return True
         return False

--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from aiohue.v2.controllers.events import EventType
 from aiohue.v2.models.scene import Scene, SceneActiveStatus
 from aiohue.v2.models.smart_scene import SmartScene, SmartSceneState
 
@@ -50,8 +51,11 @@ class SceneActivityTracker:
             return
 
         def _handle_scene_event(
-            event_type: object, scene: Scene | SmartScene
+            event_type: EventType, scene: Scene | SmartScene
         ) -> None:
+            if event_type == EventType.RESOURCE_DELETED:
+                self._clear_deleted_scene(scene)
+                return
             if self._apply_scene_update(scene):
                 group_id = scene.group.rid
                 for listener in list(self._listeners[group_id]):
@@ -90,6 +94,34 @@ class SceneActivityTracker:
             self._listeners[group_id].remove(listener)
 
         return _remove
+
+    def _clear_deleted_scene(self, scene: Scene | SmartScene) -> None:
+        """Clear group state when a tracked scene is deleted."""
+        if not isinstance(scene, (Scene, SmartScene)):
+            return
+        group_id = scene.group.rid
+        group_state = self._group_states.get(group_id)
+        if group_state is None:
+            return
+        changed = False
+        if isinstance(scene, Scene) and group_state.active_scene_id == scene.id:
+            group_state.active_scene_id = None
+            group_state.active_scene_name = None
+            group_state.active_scene_mode = None
+            group_state.active_scene_last_recall = None
+            group_state.active_scene_speed = None
+            group_state.active_scene_brightness = None
+            changed = True
+        elif (
+            isinstance(scene, SmartScene)
+            and group_state.active_smart_scene_id == scene.id
+        ):
+            group_state.active_smart_scene_id = None
+            group_state.active_smart_scene_name = None
+            changed = True
+        if changed:
+            for listener in list(self._listeners.get(group_id, [])):
+                listener(group_id)
 
     def _apply_scene_update(self, scene: Scene | SmartScene) -> bool:
         """Apply scene state to group tracking. Returns True if state changed."""

--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -1,0 +1,138 @@
+"""Track active scene per Hue group (room/zone)."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from aiohue.v2.models.scene import Scene, SceneActiveStatus
+from aiohue.v2.models.smart_scene import SmartScene, SmartSceneState
+
+if TYPE_CHECKING:
+    from aiohue.v2.controllers.scenes import ScenesController
+
+UpdateListener = Callable[[str], None]
+
+
+@dataclass(slots=True)
+class GroupSceneState:
+    """Holds active scene data for a Hue group (room/zone)."""
+
+    # Regular scene state
+    active_scene_id: str | None = None
+    active_scene_name: str | None = None
+    active_scene_mode: str | None = None  # "static" | "dynamic_palette"
+    active_scene_last_recall: datetime | None = None
+    active_scene_speed: float | None = None  # 0.0–1.0 when dynamic palette active
+    active_scene_brightness: float | None = None  # 0.0–100.0
+
+    # Smart scene state
+    active_smart_scene_id: str | None = None
+    active_smart_scene_name: str | None = None
+
+
+class SceneActivityTracker:
+    """Track active (smart) scenes per Hue group and dispatch updates."""
+
+    def __init__(self, scenes: ScenesController) -> None:
+        """Initialize the tracker."""
+        self._scenes = scenes
+        self._group_states: dict[str, GroupSceneState] = defaultdict(GroupSceneState)
+        self._listeners: dict[str, list[UpdateListener]] = defaultdict(list)
+        self._unsub: Callable[[], None] | None = None
+
+    def start(self) -> None:
+        """Subscribe to scene events and seed initial state (idempotent)."""
+        if self._unsub is not None:
+            return
+
+        def _handle_scene_event(
+            event_type: object, scene: Scene | SmartScene
+        ) -> None:
+            if self._apply_scene_update(scene):
+                group_id = scene.group.rid
+                for listener in list(self._listeners[group_id]):
+                    listener(group_id)
+
+        self._unsub = self._scenes.subscribe(_handle_scene_event)
+
+        updated_group_ids: set[str] = set()
+        for smart_scene in self._scenes.smart_scene:
+            if self._apply_scene_update(smart_scene):
+                updated_group_ids.add(smart_scene.group.rid)
+        for scene in self._scenes.scene:
+            if self._apply_scene_update(scene):
+                updated_group_ids.add(scene.group.rid)
+        for group_id in updated_group_ids:
+            for listener in list(self._listeners.get(group_id, [])):
+                listener(group_id)
+
+    def stop(self) -> None:
+        """Stop listening to scene events."""
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+
+    def get_group_state(self, group_id: str) -> GroupSceneState:
+        """Return (and lazily create) the state holder for a group."""
+        return self._group_states[group_id]
+
+    def subscribe(
+        self, group_id: str, listener: UpdateListener
+    ) -> Callable[[], None]:
+        """Register a listener for a group; return an unsubscribe callable."""
+        self._listeners[group_id].append(listener)
+
+        def _remove() -> None:
+            self._listeners[group_id].remove(listener)
+
+        return _remove
+
+    def _apply_scene_update(self, scene: Scene | SmartScene) -> bool:
+        """Apply scene state to group tracking. Returns True if state changed."""
+        if not scene.id:
+            return False
+        group_id = scene.group.rid
+        group_state = self._group_states[group_id]
+
+        if isinstance(scene, Scene):
+            if scene.status is None:
+                return False
+            if scene.status.active != SceneActiveStatus.INACTIVE:
+                group_state.active_scene_id = scene.id
+                group_state.active_scene_name = scene.metadata.name
+                group_state.active_scene_mode = scene.status.active.value
+                group_state.active_scene_last_recall = scene.status.last_recall
+                group_state.active_scene_speed = scene.speed
+                group_state.active_scene_brightness = next(
+                    (
+                        action.action.dimming.brightness
+                        for action in scene.actions
+                        if action.action.dimming is not None
+                    ),
+                    None,
+                )
+                return True
+            if group_state.active_scene_id == scene.id:
+                group_state.active_scene_id = None
+                group_state.active_scene_name = None
+                group_state.active_scene_mode = None
+                group_state.active_scene_last_recall = None
+                group_state.active_scene_speed = None
+                group_state.active_scene_brightness = None
+                return True
+            return False
+
+        if isinstance(scene, SmartScene):
+            if scene.state == SmartSceneState.ACTIVE:
+                group_state.active_smart_scene_id = scene.id
+                group_state.active_smart_scene_name = scene.metadata.name
+                return True
+            if group_state.active_smart_scene_id == scene.id:
+                group_state.active_smart_scene_id = None
+                group_state.active_smart_scene_name = None
+                return True
+        return False

--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -84,9 +84,7 @@ class SceneActivityTracker:
         """Return (and lazily create) the state holder for a group."""
         return self._group_states[group_id]
 
-    def subscribe(
-        self, group_id: str, listener: UpdateListener
-    ) -> Callable[[], None]:
+    def subscribe(self, group_id: str, listener: UpdateListener) -> Callable[[], None]:
         """Register a listener for a group; return an unsubscribe callable."""
         self._listeners[group_id].append(listener)
 

--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -25,9 +25,9 @@ class GroupSceneState:
     # Regular scene state
     active_scene_id: str | None = None
     active_scene_name: str | None = None
-    active_scene_mode: str | None = None  # "static" | "dynamic_palette"
+    active_scene_mode: str | None = None  # "static" | "dynamic_palette" | "unknown"
     active_scene_last_recall: datetime | None = None
-    active_scene_speed: float | None = None  # 0.0–1.0 when dynamic palette active
+    active_scene_speed: float | None = None  # 0.0–1.0 (scene speed; used for dynamic palette)
     active_scene_brightness: float | None = None  # 0.0–100.0
 
     # Smart scene state

--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -27,7 +27,9 @@ class GroupSceneState:
     active_scene_name: str | None = None
     active_scene_mode: str | None = None  # "static" | "dynamic_palette" | "unknown"
     active_scene_last_recall: datetime | None = None
-    active_scene_speed: float | None = None  # 0.0–1.0 (scene speed; used for dynamic palette)
+    active_scene_speed: float | None = (
+        None  # 0.0–1.0 (scene speed; used for dynamic palette)
+    )
     active_scene_brightness: float | None = None  # 0.0–100.0
 
     # Smart scene state

--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -20,21 +20,21 @@ UpdateListener = Callable[[str], None]
 
 @dataclass(slots=True)
 class GroupSceneState:
-    """Holds active scene data for a Hue group (room/zone)."""
+    """Hold active scene data for a Hue group.
+
+    A smart scene and its effective regular scene can be active at the same time.
+    In that case, both ``smart_scene_id`` and ``scene_id`` are set.
+    """
 
     # Regular scene state
-    active_scene_id: str | None = None
-    active_scene_name: str | None = None
-    active_scene_mode: str | None = None  # "static" | "dynamic_palette" | "unknown"
-    active_scene_last_recall: datetime | None = None
-    active_scene_speed: float | None = (
-        None  # 0.0–1.0 (scene speed; used for dynamic palette)
-    )
-    active_scene_brightness: float | None = None  # 0.0–100.0
+    scene_id: str | None = None
+    scene_mode: SceneActiveStatus | None = None
+    scene_last_recall: datetime | None = None
+    scene_speed: float | None = None  # 0.0–1.0 (scene speed; used for dynamic palette)
+    scene_brightness: float | None = None  # 0.0–100.0
 
     # Smart scene state
-    active_smart_scene_id: str | None = None
-    active_smart_scene_name: str | None = None
+    smart_scene_id: str | None = None
 
 
 class SceneActivityTracker:
@@ -104,20 +104,15 @@ class SceneActivityTracker:
         if group_state is None:
             return
         changed = False
-        if isinstance(scene, Scene) and group_state.active_scene_id == scene.id:
-            group_state.active_scene_id = None
-            group_state.active_scene_name = None
-            group_state.active_scene_mode = None
-            group_state.active_scene_last_recall = None
-            group_state.active_scene_speed = None
-            group_state.active_scene_brightness = None
+        if isinstance(scene, Scene) and group_state.scene_id == scene.id:
+            group_state.scene_id = None
+            group_state.scene_mode = None
+            group_state.scene_last_recall = None
+            group_state.scene_speed = None
+            group_state.scene_brightness = None
             changed = True
-        elif (
-            isinstance(scene, SmartScene)
-            and group_state.active_smart_scene_id == scene.id
-        ):
-            group_state.active_smart_scene_id = None
-            group_state.active_smart_scene_name = None
+        elif isinstance(scene, SmartScene) and group_state.smart_scene_id == scene.id:
+            group_state.smart_scene_id = None
             changed = True
         if changed:
             for listener in list(self._listeners.get(group_id, [])):
@@ -141,12 +136,11 @@ class SceneActivityTracker:
         if scene.status is None:
             return False
         if scene.status.active != SceneActiveStatus.INACTIVE:
-            group_state.active_scene_id = scene.id
-            group_state.active_scene_name = scene.metadata.name
-            group_state.active_scene_mode = scene.status.active.value
-            group_state.active_scene_last_recall = scene.status.last_recall
-            group_state.active_scene_speed = scene.speed
-            group_state.active_scene_brightness = next(
+            group_state.scene_id = scene.id
+            group_state.scene_mode = scene.status.active
+            group_state.scene_last_recall = scene.status.last_recall
+            group_state.scene_speed = scene.speed
+            group_state.scene_brightness = next(
                 (
                     action.action.dimming.brightness
                     for action in scene.actions
@@ -155,13 +149,12 @@ class SceneActivityTracker:
                 None,
             )
             return True
-        if group_state.active_scene_id == scene.id:
-            group_state.active_scene_id = None
-            group_state.active_scene_name = None
-            group_state.active_scene_mode = None
-            group_state.active_scene_last_recall = None
-            group_state.active_scene_speed = None
-            group_state.active_scene_brightness = None
+        if group_state.scene_id == scene.id:
+            group_state.scene_id = None
+            group_state.scene_mode = None
+            group_state.scene_last_recall = None
+            group_state.scene_speed = None
+            group_state.scene_brightness = None
             return True
         return False
 
@@ -170,11 +163,9 @@ class SceneActivityTracker:
     ) -> bool:
         """Update group state from a smart scene event. Returns True if changed."""
         if scene.state == SmartSceneState.ACTIVE:
-            group_state.active_smart_scene_id = scene.id
-            group_state.active_smart_scene_name = scene.metadata.name
+            group_state.smart_scene_id = scene.id
             return True
-        if group_state.active_smart_scene_id == scene.id:
-            group_state.active_smart_scene_id = None
-            group_state.active_smart_scene_name = None
+        if group_state.smart_scene_id == scene.id:
+            group_state.smart_scene_id = None
             return True
         return False

--- a/aiohue/v2/scene_activity.py
+++ b/aiohue/v2/scene_activity.py
@@ -1,4 +1,4 @@
-"""Track active scene per Hue group (room/zone)."""
+"""Track active Hue scenes per group."""
 
 from __future__ import annotations
 
@@ -22,23 +22,25 @@ UpdateListener = Callable[[str], None]
 class GroupSceneState:
     """Hold active scene data for a Hue group.
 
-    A smart scene and its effective regular scene can be active at the same time.
-    In that case, both ``smart_scene_id`` and ``scene_id`` are set.
+    - ``scene_id``: smart scene if active, else regular scene, else ``None``
+    - ``effective_scene_id``: the regular scene currently in effect, else ``None``
+
+    When any scene is active both IDs are set. For a regular scene they match;
+    for a smart scene, ``scene_id`` is the smart scene and ``effective_scene_id``
+    is the underlying regular scene. Mode/speed/brightness describe the
+    effective scene.
     """
 
-    # Regular scene state
     scene_id: str | None = None
+    effective_scene_id: str | None = None
     scene_mode: SceneActiveStatus | None = None
     scene_last_recall: datetime | None = None
-    scene_speed: float | None = None  # 0.0–1.0 (scene speed; used for dynamic palette)
-    scene_brightness: float | None = None  # 0.0–100.0
-
-    # Smart scene state
-    smart_scene_id: str | None = None
+    scene_speed: float | None = None
+    scene_brightness: float | None = None
 
 
 class SceneActivityTracker:
-    """Track active (smart) scenes per Hue group and dispatch updates."""
+    """Track active scenes per Hue group and dispatch updates."""
 
     def __init__(self, scenes: ScenesController) -> None:
         """Initialize the tracker."""
@@ -48,7 +50,7 @@ class SceneActivityTracker:
         self._unsub: Callable[[], None] | None = None
 
     def start(self) -> None:
-        """Subscribe to scene events and seed initial state (idempotent)."""
+        """Subscribe to scene events and seed initial state."""
         if self._unsub is not None:
             return
 
@@ -83,11 +85,11 @@ class SceneActivityTracker:
             self._unsub = None
 
     def get_group_state(self, group_id: str) -> GroupSceneState:
-        """Return (and lazily create) the state holder for a group."""
+        """Return the state holder for a group."""
         return self._group_states[group_id]
 
     def subscribe(self, group_id: str, listener: UpdateListener) -> Callable[[], None]:
-        """Register a listener for a group; return an unsubscribe callable."""
+        """Register a listener for a group."""
         self._listeners[group_id].append(listener)
 
         def _remove() -> None:
@@ -104,22 +106,19 @@ class SceneActivityTracker:
         if group_state is None:
             return
         changed = False
-        if isinstance(scene, Scene) and group_state.scene_id == scene.id:
-            group_state.scene_id = None
-            group_state.scene_mode = None
-            group_state.scene_last_recall = None
-            group_state.scene_speed = None
-            group_state.scene_brightness = None
+        if isinstance(scene, Scene) and group_state.effective_scene_id == scene.id:
+            self._clear_effective_scene(group_state)
             changed = True
-        elif isinstance(scene, SmartScene) and group_state.smart_scene_id == scene.id:
-            group_state.smart_scene_id = None
+        elif isinstance(scene, SmartScene) and group_state.scene_id == scene.id:
+            # Fall back to the effective regular scene, if any.
+            group_state.scene_id = group_state.effective_scene_id
             changed = True
         if changed:
             for listener in list(self._listeners.get(group_id, [])):
                 listener(group_id)
 
     def _apply_scene_update(self, scene: Scene | SmartScene) -> bool:
-        """Apply scene state to group tracking. Returns True if state changed."""
+        """Apply scene state to group tracking."""
         if not scene.id:
             return False
         group_state = self._group_states[scene.group.rid]
@@ -132,11 +131,17 @@ class SceneActivityTracker:
     def _apply_regular_scene_update(
         self, scene: Scene, group_state: GroupSceneState
     ) -> bool:
-        """Update group state from a regular scene event. Returns True if changed."""
+        """Update group state from a regular scene event."""
         if scene.status is None:
             return False
         if scene.status.active != SceneActiveStatus.INACTIVE:
-            group_state.scene_id = scene.id
+            # scene_id differs from effective_scene_id only while a smart scene
+            # is selected; keep that selection when the effective regular changes.
+            smart_active = (
+                group_state.scene_id is not None
+                and group_state.scene_id != group_state.effective_scene_id
+            )
+            group_state.effective_scene_id = scene.id
             group_state.scene_mode = scene.status.active
             group_state.scene_last_recall = scene.status.last_recall
             group_state.scene_speed = scene.speed
@@ -148,24 +153,33 @@ class SceneActivityTracker:
                 ),
                 None,
             )
+            if not smart_active:
+                group_state.scene_id = scene.id
             return True
-        if group_state.scene_id == scene.id:
-            group_state.scene_id = None
-            group_state.scene_mode = None
-            group_state.scene_last_recall = None
-            group_state.scene_speed = None
-            group_state.scene_brightness = None
+        if group_state.effective_scene_id == scene.id:
+            self._clear_effective_scene(group_state)
             return True
         return False
 
     def _apply_smart_scene_update(
         self, scene: SmartScene, group_state: GroupSceneState
     ) -> bool:
-        """Update group state from a smart scene event. Returns True if changed."""
+        """Update group state from a smart scene event."""
         if scene.state == SmartSceneState.ACTIVE:
-            group_state.smart_scene_id = scene.id
+            group_state.scene_id = scene.id
             return True
-        if group_state.smart_scene_id == scene.id:
-            group_state.smart_scene_id = None
+        if group_state.scene_id == scene.id:
+            group_state.scene_id = group_state.effective_scene_id
             return True
         return False
+
+    @staticmethod
+    def _clear_effective_scene(group_state: GroupSceneState) -> None:
+        """Clear effective regular-scene fields on a group state."""
+        if group_state.scene_id == group_state.effective_scene_id:
+            group_state.scene_id = None
+        group_state.effective_scene_id = None
+        group_state.scene_mode = None
+        group_state.scene_last_recall = None
+        group_state.scene_speed = None
+        group_state.scene_brightness = None

--- a/tests/v2/test_scene_activity_tracker.py
+++ b/tests/v2/test_scene_activity_tracker.py
@@ -1,0 +1,351 @@
+"""Tests for SceneActivityTracker."""
+
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+from aiohue import HueBridgeV2
+from aiohue.v2.controllers.events import EventType
+from aiohue.v2.models.scene import SceneActiveStatus
+from aiohue.v2.scene_activity import SceneActivityTracker
+
+
+def _scene_data(
+    scene_id: str,
+    group_id: str,
+    name: str,
+    active: str,
+    brightness: float | None = None,
+) -> dict:
+    """Build a minimal scene event data dict."""
+    actions = []
+    if brightness is not None:
+        actions = [
+            {
+                "target": {"rid": str(uuid4()), "rtype": "light"},
+                "action": {"dimming": {"brightness": brightness}},
+            }
+        ]
+    return {
+        "id": scene_id,
+        "type": "scene",
+        "metadata": {"name": name},
+        "group": {"rid": group_id, "rtype": "room"},
+        "actions": actions,
+        "speed": 0.5,
+        "status": {"active": active},
+    }
+
+
+def _smart_scene_data(scene_id: str, group_id: str, name: str, state: str) -> dict:
+    """Build a minimal smart scene event data dict."""
+    return {
+        "id": scene_id,
+        "type": "smart_scene",
+        "metadata": {"name": name},
+        "group": {"rid": group_id, "rtype": "room"},
+        "week_timeslots": [],
+        "state": state,
+    }
+
+
+async def test_active_scene_sets_state() -> None:
+    """After a scene becomes active, group state reflects name and mode."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Relax", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "scene", "status": {"active": "static"}},
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_id == scene_id
+    assert state.active_scene_name == "Relax"
+    assert state.active_scene_mode == "static"
+
+
+async def test_inactive_scene_clears_state() -> None:
+    """When the tracked scene becomes inactive, group state is cleared."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Relax", "static"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    # scene is now tracked as active; make it inactive
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "scene", "status": {"active": "inactive"}},
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_id is None
+    assert state.active_scene_name is None
+    assert state.active_scene_mode is None
+
+
+async def test_inactive_event_for_untracked_scene_ignored() -> None:
+    """An inactive update for a scene not currently tracked does not change state."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_a = str(uuid4())
+    scene_b = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_a, group_id, "Relax", "static"),
+    )
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_b, group_id, "Energize", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    # scene_a is active; fire inactive event for scene_b (not tracked)
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_b, "type": "scene", "status": {"active": "inactive"}},
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_id == scene_a
+    assert state.active_scene_name == "Relax"
+
+
+async def test_listener_called_on_update() -> None:
+    """A subscribed listener is called with the group_id when state changes."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Relax", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    listener = Mock()
+    tracker.subscribe(group_id, listener)
+
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "scene", "status": {"active": "static"}},
+    )
+
+    listener.assert_called_once_with(group_id)
+
+
+async def test_listener_unsubscribe() -> None:
+    """After unsubscribing, the listener is no longer called."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Relax", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    listener = Mock()
+    unsubscribe = tracker.subscribe(group_id, listener)
+    unsubscribe()
+
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "scene", "status": {"active": "static"}},
+    )
+
+    listener.assert_not_called()
+
+
+async def test_active_smart_scene_sets_state() -> None:
+    """When a smart scene becomes active, group state reflects its name."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _smart_scene_data(scene_id, group_id, "Morning", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "smart_scene", "state": "active"},
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_smart_scene_id == scene_id
+    assert state.active_smart_scene_name == "Morning"
+
+
+async def test_inactive_smart_scene_clears_state() -> None:
+    """When the tracked smart scene becomes inactive, its state is cleared."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _smart_scene_data(scene_id, group_id, "Morning", "active"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "smart_scene", "state": "inactive"},
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_smart_scene_id is None
+    assert state.active_smart_scene_name is None
+
+
+async def test_start_seeds_initial_state(v2_resources) -> None:
+    """start() picks up already-active scenes from the controller."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    with patch.object(bridge, "request", return_value=v2_resources):
+        await bridge.fetch_full_state()
+
+    active_scenes = [
+        s
+        for s in bridge.scenes.scene
+        if s.status and s.status.active != SceneActiveStatus.INACTIVE
+    ]
+    assert len(active_scenes) > 0, "fixture must contain at least one active scene"
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    for scene in active_scenes:
+        state = tracker.get_group_state(scene.group.rid)
+        assert state.active_scene_name == scene.metadata.name
+
+
+async def test_stop_unsubscribes() -> None:
+    """After stop(), scene events no longer update group state or call listeners."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Relax", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    listener = Mock()
+    tracker.subscribe(group_id, listener)
+
+    tracker.stop()
+
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "scene", "status": {"active": "static"}},
+    )
+
+    listener.assert_not_called()
+    assert tracker.get_group_state(group_id).active_scene_id is None
+
+
+async def test_dynamic_palette_mode() -> None:
+    """A dynamic_palette active status is reflected in active_scene_mode."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Aurora", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {
+            "id": scene_id,
+            "type": "scene",
+            "status": {"active": "dynamic_palette"},
+        },
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_mode == "dynamic_palette"
+
+
+async def test_brightness_extracted_from_actions() -> None:
+    """Brightness is read from the first action with a dimming field."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Bright", "static", brightness=80.0),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_brightness == 80.0
+
+
+async def test_brightness_none_when_no_dimming_action() -> None:
+    """Brightness is None when no scene action has a dimming field."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "No Dimming", "static", brightness=None),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_brightness is None

--- a/tests/v2/test_scene_activity_tracker.py
+++ b/tests/v2/test_scene_activity_tracker.py
@@ -332,6 +332,91 @@ async def test_brightness_extracted_from_actions() -> None:
     assert state.active_scene_brightness == 80.0
 
 
+async def test_deleted_active_scene_clears_state() -> None:
+    """Deleting the tracked active scene clears group state and notifies listeners."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Relax", "static"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    listener = Mock()
+    tracker.subscribe(group_id, listener)
+
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_DELETED, {"id": scene_id, "type": "scene"}
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_id is None
+    assert state.active_scene_name is None
+    listener.assert_called_once_with(group_id)
+
+
+async def test_deleted_inactive_scene_does_not_notify() -> None:
+    """Deleting a scene that was not tracked as active does not notify listeners."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_a = str(uuid4())
+    scene_b = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_a, group_id, "Relax", "static"),
+    )
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_b, group_id, "Energize", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    listener = Mock()
+    tracker.subscribe(group_id, listener)
+
+    # Delete the inactive scene — should not touch state or notify
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_DELETED, {"id": scene_b, "type": "scene"}
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_scene_id == scene_a
+    listener.assert_not_called()
+
+
+async def test_deleted_active_smart_scene_clears_state() -> None:
+    """Deleting the tracked active smart scene clears its group state."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _smart_scene_data(scene_id, group_id, "Morning", "active"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_DELETED, {"id": scene_id, "type": "smart_scene"}
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.active_smart_scene_id is None
+    assert state.active_smart_scene_name is None
+
+
 async def test_brightness_none_when_no_dimming_action() -> None:
     """Brightness is None when no scene action has a dimming field."""
     bridge = HueBridgeV2("127.0.0.1", "fake")

--- a/tests/v2/test_scene_activity_tracker.py
+++ b/tests/v2/test_scene_activity_tracker.py
@@ -49,7 +49,7 @@ def _smart_scene_data(scene_id: str, group_id: str, name: str, state: str) -> di
 
 
 async def test_active_scene_sets_state() -> None:
-    """After a scene becomes active, group state reflects name and mode."""
+    """After a scene becomes active, group state reflects its ID and mode."""
     bridge = HueBridgeV2("127.0.0.1", "fake")
     scene_id = str(uuid4())
     group_id = str(uuid4())
@@ -69,9 +69,8 @@ async def test_active_scene_sets_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_id == scene_id
-    assert state.active_scene_name == "Relax"
-    assert state.active_scene_mode == "static"
+    assert state.scene_id == scene_id
+    assert state.scene_mode is SceneActiveStatus.STATIC
 
 
 async def test_inactive_scene_clears_state() -> None:
@@ -96,9 +95,8 @@ async def test_inactive_scene_clears_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_id is None
-    assert state.active_scene_name is None
-    assert state.active_scene_mode is None
+    assert state.scene_id is None
+    assert state.scene_mode is None
 
 
 async def test_inactive_event_for_untracked_scene_ignored() -> None:
@@ -128,8 +126,7 @@ async def test_inactive_event_for_untracked_scene_ignored() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_id == scene_a
-    assert state.active_scene_name == "Relax"
+    assert state.scene_id == scene_a
 
 
 async def test_listener_called_on_update() -> None:
@@ -186,7 +183,7 @@ async def test_listener_unsubscribe() -> None:
 
 
 async def test_active_smart_scene_sets_state() -> None:
-    """When a smart scene becomes active, group state reflects its name."""
+    """When a smart scene becomes active, group state reflects its ID."""
     bridge = HueBridgeV2("127.0.0.1", "fake")
     scene_id = str(uuid4())
     group_id = str(uuid4())
@@ -206,8 +203,7 @@ async def test_active_smart_scene_sets_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_smart_scene_id == scene_id
-    assert state.active_smart_scene_name == "Morning"
+    assert state.smart_scene_id == scene_id
 
 
 async def test_inactive_smart_scene_clears_state() -> None:
@@ -231,8 +227,52 @@ async def test_inactive_smart_scene_clears_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_smart_scene_id is None
-    assert state.active_smart_scene_name is None
+    assert state.smart_scene_id is None
+
+
+async def test_regular_and_smart_scene_state_coexist() -> None:
+    """A smart scene and its effective regular scene are tracked independently."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    smart_scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Relax", "static"),
+    )
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _smart_scene_data(smart_scene_id, group_id, "Morning", "active"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    state = tracker.get_group_state(group_id)
+    assert state.scene_id == scene_id
+    assert state.smart_scene_id == smart_scene_id
+
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": smart_scene_id, "type": "smart_scene", "state": "inactive"},
+    )
+
+    assert state.scene_id == scene_id
+    assert state.smart_scene_id is None
+
+    await bridge.scenes.smart_scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": smart_scene_id, "type": "smart_scene", "state": "active"},
+    )
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "scene", "status": {"active": "inactive"}},
+    )
+
+    assert state.scene_id is None
+    assert state.smart_scene_id == smart_scene_id
 
 
 async def test_start_seeds_initial_state(v2_resources) -> None:
@@ -253,7 +293,7 @@ async def test_start_seeds_initial_state(v2_resources) -> None:
 
     for scene in active_scenes:
         state = tracker.get_group_state(scene.group.rid)
-        assert state.active_scene_name == scene.metadata.name
+        assert state.scene_id == scene.id
 
 
 async def test_stop_unsubscribes() -> None:
@@ -282,11 +322,11 @@ async def test_stop_unsubscribes() -> None:
     )
 
     listener.assert_not_called()
-    assert tracker.get_group_state(group_id).active_scene_id is None
+    assert tracker.get_group_state(group_id).scene_id is None
 
 
 async def test_dynamic_palette_mode() -> None:
-    """A dynamic_palette active status is reflected in active_scene_mode."""
+    """A dynamic_palette active status is reflected in scene_mode."""
     bridge = HueBridgeV2("127.0.0.1", "fake")
     scene_id = str(uuid4())
     group_id = str(uuid4())
@@ -310,7 +350,32 @@ async def test_dynamic_palette_mode() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_mode == "dynamic_palette"
+    assert state.scene_mode is SceneActiveStatus.DYNAMIC_PALETTE
+
+
+async def test_unknown_scene_mode() -> None:
+    """An unrecognized Hue scene mode is preserved as the enum sentinel."""
+    bridge = HueBridgeV2("127.0.0.1", "fake")
+    scene_id = str(uuid4())
+    group_id = str(uuid4())
+
+    # pylint: disable=protected-access
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_ADDED,
+        _scene_data(scene_id, group_id, "Future scene", "inactive"),
+    )
+
+    tracker = SceneActivityTracker(bridge.scenes)
+    tracker.start()
+
+    await bridge.scenes.scene._handle_event(
+        EventType.RESOURCE_UPDATED,
+        {"id": scene_id, "type": "scene", "status": {"active": "future_mode"}},
+    )
+
+    state = tracker.get_group_state(group_id)
+    assert state.scene_id == scene_id
+    assert state.scene_mode is SceneActiveStatus.UNKNOWN
 
 
 async def test_brightness_extracted_from_actions() -> None:
@@ -329,7 +394,7 @@ async def test_brightness_extracted_from_actions() -> None:
     tracker.start()
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_brightness == 80.0
+    assert state.scene_brightness == 80.0
 
 
 async def test_deleted_active_scene_clears_state() -> None:
@@ -355,8 +420,7 @@ async def test_deleted_active_scene_clears_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_id is None
-    assert state.active_scene_name is None
+    assert state.scene_id is None
     listener.assert_called_once_with(group_id)
 
 
@@ -389,7 +453,7 @@ async def test_deleted_inactive_scene_does_not_notify() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_id == scene_a
+    assert state.scene_id == scene_a
     listener.assert_not_called()
 
 
@@ -413,8 +477,7 @@ async def test_deleted_active_smart_scene_clears_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.active_smart_scene_id is None
-    assert state.active_smart_scene_name is None
+    assert state.smart_scene_id is None
 
 
 async def test_brightness_none_when_no_dimming_action() -> None:
@@ -433,4 +496,4 @@ async def test_brightness_none_when_no_dimming_action() -> None:
     tracker.start()
 
     state = tracker.get_group_state(group_id)
-    assert state.active_scene_brightness is None
+    assert state.scene_brightness is None

--- a/tests/v2/test_scene_activity_tracker.py
+++ b/tests/v2/test_scene_activity_tracker.py
@@ -70,6 +70,7 @@ async def test_active_scene_sets_state() -> None:
 
     state = tracker.get_group_state(group_id)
     assert state.scene_id == scene_id
+    assert state.effective_scene_id == scene_id
     assert state.scene_mode is SceneActiveStatus.STATIC
 
 
@@ -96,6 +97,7 @@ async def test_inactive_scene_clears_state() -> None:
 
     state = tracker.get_group_state(group_id)
     assert state.scene_id is None
+    assert state.effective_scene_id is None
     assert state.scene_mode is None
 
 
@@ -127,6 +129,7 @@ async def test_inactive_event_for_untracked_scene_ignored() -> None:
 
     state = tracker.get_group_state(group_id)
     assert state.scene_id == scene_a
+    assert state.effective_scene_id == scene_a
 
 
 async def test_listener_called_on_update() -> None:
@@ -183,7 +186,7 @@ async def test_listener_unsubscribe() -> None:
 
 
 async def test_active_smart_scene_sets_state() -> None:
-    """When a smart scene becomes active, group state reflects its ID."""
+    """When a smart scene becomes active, scene_id is the smart scene."""
     bridge = HueBridgeV2("127.0.0.1", "fake")
     scene_id = str(uuid4())
     group_id = str(uuid4())
@@ -203,7 +206,8 @@ async def test_active_smart_scene_sets_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.smart_scene_id == scene_id
+    assert state.scene_id == scene_id
+    assert state.effective_scene_id is None
 
 
 async def test_inactive_smart_scene_clears_state() -> None:
@@ -227,20 +231,25 @@ async def test_inactive_smart_scene_clears_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.smart_scene_id is None
+    assert state.scene_id is None
+    assert state.effective_scene_id is None
 
 
 async def test_regular_and_smart_scene_state_coexist() -> None:
-    """A smart scene and its effective regular scene are tracked independently."""
+    """Smart scene and effective regular scene are tracked independently.
+
+    scene_id prefers the smart scene for the UI dropdown; effective_scene_id
+    always reflects the underlying regular scene.
+    """
     bridge = HueBridgeV2("127.0.0.1", "fake")
-    scene_id = str(uuid4())
+    regular_scene_id = str(uuid4())
     smart_scene_id = str(uuid4())
     group_id = str(uuid4())
 
     # pylint: disable=protected-access
     await bridge.scenes.scene._handle_event(
         EventType.RESOURCE_ADDED,
-        _scene_data(scene_id, group_id, "Relax", "static"),
+        _scene_data(regular_scene_id, group_id, "Relax", "static"),
     )
     await bridge.scenes.smart_scene._handle_event(
         EventType.RESOURCE_ADDED,
@@ -251,16 +260,16 @@ async def test_regular_and_smart_scene_state_coexist() -> None:
     tracker.start()
 
     state = tracker.get_group_state(group_id)
-    assert state.scene_id == scene_id
-    assert state.smart_scene_id == smart_scene_id
+    assert state.scene_id == smart_scene_id
+    assert state.effective_scene_id == regular_scene_id
 
     await bridge.scenes.smart_scene._handle_event(
         EventType.RESOURCE_UPDATED,
         {"id": smart_scene_id, "type": "smart_scene", "state": "inactive"},
     )
 
-    assert state.scene_id == scene_id
-    assert state.smart_scene_id is None
+    assert state.scene_id == regular_scene_id
+    assert state.effective_scene_id == regular_scene_id
 
     await bridge.scenes.smart_scene._handle_event(
         EventType.RESOURCE_UPDATED,
@@ -268,11 +277,11 @@ async def test_regular_and_smart_scene_state_coexist() -> None:
     )
     await bridge.scenes.scene._handle_event(
         EventType.RESOURCE_UPDATED,
-        {"id": scene_id, "type": "scene", "status": {"active": "inactive"}},
+        {"id": regular_scene_id, "type": "scene", "status": {"active": "inactive"}},
     )
 
-    assert state.scene_id is None
-    assert state.smart_scene_id == smart_scene_id
+    assert state.scene_id == smart_scene_id
+    assert state.effective_scene_id is None
 
 
 async def test_start_seeds_initial_state(v2_resources) -> None:
@@ -293,7 +302,9 @@ async def test_start_seeds_initial_state(v2_resources) -> None:
 
     for scene in active_scenes:
         state = tracker.get_group_state(scene.group.rid)
-        assert state.scene_id == scene.id
+        # effective_scene_id always tracks the regular scene; scene_id may be a
+        # smart scene if one is also active for the group.
+        assert state.effective_scene_id == scene.id
 
 
 async def test_stop_unsubscribes() -> None:
@@ -323,6 +334,7 @@ async def test_stop_unsubscribes() -> None:
 
     listener.assert_not_called()
     assert tracker.get_group_state(group_id).scene_id is None
+    assert tracker.get_group_state(group_id).effective_scene_id is None
 
 
 async def test_dynamic_palette_mode() -> None:
@@ -351,6 +363,7 @@ async def test_dynamic_palette_mode() -> None:
 
     state = tracker.get_group_state(group_id)
     assert state.scene_mode is SceneActiveStatus.DYNAMIC_PALETTE
+    assert state.effective_scene_id == scene_id
 
 
 async def test_unknown_scene_mode() -> None:
@@ -375,6 +388,7 @@ async def test_unknown_scene_mode() -> None:
 
     state = tracker.get_group_state(group_id)
     assert state.scene_id == scene_id
+    assert state.effective_scene_id == scene_id
     assert state.scene_mode is SceneActiveStatus.UNKNOWN
 
 
@@ -421,6 +435,7 @@ async def test_deleted_active_scene_clears_state() -> None:
 
     state = tracker.get_group_state(group_id)
     assert state.scene_id is None
+    assert state.effective_scene_id is None
     listener.assert_called_once_with(group_id)
 
 
@@ -454,6 +469,7 @@ async def test_deleted_inactive_scene_does_not_notify() -> None:
 
     state = tracker.get_group_state(group_id)
     assert state.scene_id == scene_a
+    assert state.effective_scene_id == scene_a
     listener.assert_not_called()
 
 
@@ -477,7 +493,8 @@ async def test_deleted_active_smart_scene_clears_state() -> None:
     )
 
     state = tracker.get_group_state(group_id)
-    assert state.smart_scene_id is None
+    assert state.scene_id is None
+    assert state.effective_scene_id is None
 
 
 async def test_brightness_none_when_no_dimming_action() -> None:


### PR DESCRIPTION
## Summary

- Adds `GroupSceneState` dataclass and `SceneActivityTracker` class in `aiohue/v2/scene_activity.py`
- The tracker subscribes to `ScenesController`, seeds state from already-active scenes on `start()`, and notifies per-group listeners whenever a regular or smart scene transitions between active and inactive
- Pure library code — no Home Assistant dependencies; listeners are plain `Callable[[str], None]` and receive the group ID on each state change

## Motivation

The Home Assistant `hue` integration (home-assistant/core#151883) needed a central place to track which Hue scene is currently active per room/zone. Reviewers requested this logic be moved into aiohue rather than living in ha-core, since it tracks the state of library model instances.

## Test plan

- [ ] `pytest tests/v2/test_scene_activity_tracker.py` — 12 new tests covering active/inactive transitions for regular and smart scenes, listener subscribe/unsubscribe, `start()` seeding from pre-existing state, `stop()` cleanup, and brightness extraction
- [ ] `pytest tests/` passes in full (existing tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)