### PR TITLE
Fix resources being dropped when the bridge omits a list field

### DIFF
--- a/aiohue/util.py
+++ b/aiohue/util.py
@@ -1,7 +1,7 @@
 """Utils for aiohue."""
 
 import logging
-from dataclasses import MISSING, asdict, dataclass, fields, is_dataclass
+from dataclasses import MISSING, Field, asdict, dataclass, fields, is_dataclass
 from datetime import datetime
 from enum import Enum
 from types import NoneType, UnionType
@@ -258,11 +258,26 @@ def dataclass_from_dict(cls: dataclass, dict_obj: dict, strict=False):
                 f"{cls.__name__}.{field.name}",
                 dict_obj.get(field.name),
                 field.type,
-                field.default,
+                _field_default(field),
             )
             for field in fields(cls)
         }
     )
+
+
+def _field_default(field: Field) -> Any:
+    """
+    Return the default for a dataclass field, or MISSING if it has none.
+
+    A field declared with `default_factory` has no `default`, so its fallback
+    has to be produced by calling the factory. Without this the field is treated
+    as required and the whole resource fails to parse when the key is absent.
+    """
+    if field.default is not MISSING:
+        return field.default
+    if field.default_factory is not MISSING:
+        return field.default_factory()
+    return MISSING
 
 
 def mac_from_bridge_id(bridge_id: str) -> str:

--- a/aiohue/util.py
+++ b/aiohue/util.py
@@ -254,30 +254,29 @@ def dataclass_from_dict(cls: dataclass, dict_obj: dict, strict=False):
 
     return cls(
         **{
-            field.name: _parse_value(
-                f"{cls.__name__}.{field.name}",
-                dict_obj.get(field.name),
-                field.type,
-                _field_default(field),
-            )
+            field.name: _parse_field(cls.__name__, field, dict_obj.get(field.name))
             for field in fields(cls)
         }
     )
 
 
-def _field_default(field: Field) -> Any:
+def _parse_field(cls_name: str, field: Field, value: Any) -> Any:
     """
-    Return the default for a dataclass field, or MISSING if it has none.
+    Parse a single dataclass field from its raw value.
 
     A field declared with `default_factory` has no `default`, so its fallback
-    has to be produced by calling the factory. Without this the field is treated
-    as required and the whole resource fails to parse when the key is absent.
+    has to be produced by calling the factory. Without that the field counts as
+    required and the whole resource fails to parse when the key is absent. The
+    factory only runs when there is no value, so it cannot fire a side effect
+    for a field the bridge did send.
     """
-    if field.default is not MISSING:
-        return field.default
-    if field.default_factory is not MISSING:
-        return field.default_factory()
-    return MISSING
+    default = MISSING
+    if value is None:
+        if field.default is not MISSING:
+            default = field.default
+        elif field.default_factory is not MISSING:
+            default = field.default_factory()
+    return _parse_value(f"{cls_name}.{field.name}", value, field.type, default)
 
 
 def mac_from_bridge_id(bridge_id: str) -> str:

--- a/tests/v2/test_parser.py
+++ b/tests/v2/test_parser.py
@@ -1,7 +1,7 @@
 """Test parser functions that converts the incoming json from API into dataclass models."""
 
 import datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 
 import pytest
@@ -98,3 +98,22 @@ def test_dataclass_to_dict_serializes_enums_in_collections():
     assert result["actions"][0]["target"]["rtype"] == "light"
     # the request body is handed to json.dumps, so it must contain no Enums
     json.dumps(result)
+
+
+def test_dataclass_from_dict_uses_default_factory():
+    """Ensure a field with a default_factory is not treated as required."""
+
+    @dataclass
+    class ModelWithFactory:
+        """Test model with a default_factory field."""
+
+        a: int
+        b: list[str] = field(default_factory=list)
+
+    result = dataclass_from_dict(ModelWithFactory, {"a": 1})
+
+    assert isinstance(result.b, list)
+    assert not result.b
+    # the factory has to run per instance, not be shared between them
+    result.b.append("x")
+    assert not dataclass_from_dict(ModelWithFactory, {"a": 2}).b

--- a/tests/v2/test_parser.py
+++ b/tests/v2/test_parser.py
@@ -102,18 +102,30 @@ def test_dataclass_to_dict_serializes_enums_in_collections():
 
 def test_dataclass_from_dict_uses_default_factory():
     """Ensure a field with a default_factory is not treated as required."""
+    calls = []
+
+    def counting_factory() -> list[str]:
+        calls.append(1)
+        return []
 
     @dataclass
     class ModelWithFactory:
         """Test model with a default_factory field."""
 
         a: int
-        b: list[str] = field(default_factory=list)
+        b: list[str] = field(default_factory=counting_factory)
 
     result = dataclass_from_dict(ModelWithFactory, {"a": 1})
 
     assert isinstance(result.b, list)
     assert not result.b
+    assert len(calls) == 1
+
     # the factory has to run per instance, not be shared between them
     result.b.append("x")
     assert not dataclass_from_dict(ModelWithFactory, {"a": 2}).b
+
+    # and it must not run at all when the value is supplied
+    calls.clear()
+    assert dataclass_from_dict(ModelWithFactory, {"a": 3, "b": ["y"]}).b == ["y"]
+    assert not calls


### PR DESCRIPTION
Some model fields declare their fallback with a factory (an empty list, or a nested object). The parser only looked at plain defaults, so those fields were treated as required and the whole resource failed to parse whenever the bridge left the key out. The resource was then logged and discarded, which is silent from a user's point of view.

Sixteen fields were affected. The two that matter most:

- Scene palettes lost their `effects` list on bridges that omit it, which made the entire palette come back empty
- A MotionAware area whose participants arrive without a health status was dropped completely, so no MotionAware sensors appeared

**Changes**
- Use a field's factory as its fallback when parsing, so omitted keys fall back instead of failing
- Added a test covering it, including that each instance gets its own value

Fixes a regression from #657 for the scene palette; the MotionAware case predates it.