### PR TITLE
Add start/stop support for behavior instances

### DIFF
--- a/aiohue/v2/controllers/config.py
+++ b/aiohue/v2/controllers/config.py
@@ -134,6 +134,19 @@ class BehaviorInstanceController(BaseResourcesController[type[BehaviorInstance]]
         """Enable/Disable sensor."""
         await self.update(id, BehaviorInstancePut(enabled=enabled))
 
+    async def start(self, id: str) -> None:
+        """
+        Start a behavior instance, e.g. presence mimicking.
+
+        Enabling an instance only arms it, this actually runs it. Instances
+        that report a `presence_mimicking_state` support this.
+        """
+        await self.update(id, BehaviorInstancePut(trigger={"start": {}}))
+
+    async def stop(self, id: str) -> None:
+        """Stop a behavior instance that was started with `start`."""
+        await self.update(id, BehaviorInstancePut(trigger={"stop": {}}))
+
 
 class MotionAreaConfigurationController(
     BaseResourcesController[type[MotionAreaConfiguration]]

--- a/aiohue/v2/models/behavior_instance.py
+++ b/aiohue/v2/models/behavior_instance.py
@@ -117,7 +117,7 @@ class BehaviorInstance:
         Return the run state of a presence mimicking instance.
 
         Only presence mimicking instances report this, so None means this
-        instance can not be started and stopped.
+        instance cannot be started and stopped.
         """
         if self.state is None or (value := self.state.get("pm_state")) is None:
             return None

--- a/aiohue/v2/models/behavior_instance.py
+++ b/aiohue/v2/models/behavior_instance.py
@@ -20,6 +20,19 @@ class BehaviorInstanceStatus(Enum):
     ERRORED = "errored"
 
 
+class PresenceMimickingState(Enum):
+    """Run state of a presence mimicking behavior instance."""
+
+    STARTED = "started"
+    STOPPED = "stopped"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: type, value: object):  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return PresenceMimickingState.UNKNOWN
+
+
 @dataclass
 class BehaviorInstanceMetadata:
     """Represent BehaviorInstance Metadata object as used by BehaviorInstance resource."""
@@ -97,6 +110,18 @@ class BehaviorInstance:
     id_v1: str | None = None
     migrated_from: str | None = None
     type: ResourceTypes = ResourceTypes.BEHAVIOR_INSTANCE
+
+    @property
+    def presence_mimicking_state(self) -> PresenceMimickingState | None:
+        """
+        Return the run state of a presence mimicking instance.
+
+        Only presence mimicking instances report this, so None means this
+        instance can not be started and stopped.
+        """
+        if self.state is None or (value := self.state.get("pm_state")) is None:
+            return None
+        return PresenceMimickingState(value)
 
 
 @dataclass

--- a/tests/v2/test_behavior_instance_controller.py
+++ b/tests/v2/test_behavior_instance_controller.py
@@ -1,0 +1,58 @@
+"""Test behavior instance controller."""
+
+from unittest.mock import patch
+
+import pytest
+
+from aiohue import HueBridgeV2
+from aiohue.v2.models.behavior_instance import (
+    BehaviorInstance,
+    PresenceMimickingState,
+)
+
+BEHAVIOR_INSTANCE_ID = "ac390cd0-d0b6-208d-5e60-b1653803c88d"
+ENDPOINT = f"clip/v2/resource/behavior_instance/{BEHAVIOR_INSTANCE_ID}"
+
+
+@pytest.fixture(name="bridge")
+async def bridge_fixture(v2_resources) -> HueBridgeV2:
+    """Return a bridge with the v2 resources loaded."""
+    bridge = HueBridgeV2("192.168.1.123", "mock-key")
+    with patch.object(bridge, "request", return_value=v2_resources):
+        await bridge.fetch_full_state()
+    return bridge
+
+
+@pytest.mark.parametrize(
+    ("action", "expected"),
+    [("start", {"start": {}}), ("stop", {"stop": {}})],
+)
+async def test_start_stop(bridge: HueBridgeV2, action: str, expected: dict) -> None:
+    """Test start and stop send a trigger instead of touching enabled."""
+    controller = bridge.config.behavior_instance
+
+    with patch.object(bridge, "request", return_value=None) as mock_request:
+        await getattr(controller, action)(BEHAVIOR_INSTANCE_ID)
+
+    mock_request.assert_called_once_with("put", ENDPOINT, json={"trigger": expected})
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ({"pm_state": "started"}, PresenceMimickingState.STARTED),
+        ({"pm_state": "stopped"}, PresenceMimickingState.STOPPED),
+        ({"pm_state": "something_new"}, PresenceMimickingState.UNKNOWN),
+        ({"source_type": "device"}, None),
+        ({}, None),
+        (None, None),
+    ],
+)
+async def test_presence_mimicking_state(
+    bridge: HueBridgeV2, state: dict | None, expected: PresenceMimickingState | None
+) -> None:
+    """Test the run state is only reported for presence mimicking instances."""
+    item: BehaviorInstance = bridge.config.behavior_instance[BEHAVIOR_INSTANCE_ID]
+    item.state = state
+
+    assert item.presence_mimicking_state is expected


### PR DESCRIPTION
## Problem

Automations like presence mimicking are run from the Hue app with a play and
stop button. That maps to the `trigger` property on `behavior_instance`, and
the result comes back in `state.pm_state`. Enabling an instance only arms it,
so `enabled` could not be used to start or stop these automations, and there
was no way to read whether one was currently running.

## Changes

- `start()` and `stop()` on `BehaviorInstanceController` send the matching trigger
- `presence_mimicking_state` on `BehaviorInstance` exposes the run state, and is
  `None` for instances that can not be started and stopped

## Notes

Verified against a BSB003 on `1.78.2071401010`:

```
PUT {"trigger": {"start": {}}}  -> 200, state.pm_state: stopped -> started
PUT {"trigger": {"stop":  {}}}  -> 200, state.pm_state: started -> stopped
```

Both changes are echoed on the event stream within a second, so the run state
stays current without polling.

Worth knowing for callers: the bridge accepts an unknown trigger key with a
200 and does nothing, so a typo is not reported as an error. `state` itself is
read-only and rejects writes with `property: state not allowed`.