### PR TITLE
Harden the CI setup and link the source repo on PyPI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,29 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    # Actions are pinned to commit SHAs, so a bump is unreviewable by version
+    # alone. Let a fresh release sit for a few days before adopting it, so a
+    # compromised or broken tag has a chance to be pulled first.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"
+      - "dependencies"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -11,13 +11,18 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   pr_labels:
     name: Verify
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@2.0.0
+        uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0
         with:
           labels: >-
             breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,13 +3,19 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create and update the draft release
+      pull-requests: read # read the merged PR titles and labels
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v7.7.0
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,10 @@ on:
   release:
     types: [published]
 env:
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.13"
+
+permissions:
+  contents: read
 
 jobs:
   build-and-publish-pypi:
@@ -13,25 +16,30 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.tag }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Get tag
         id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
       - name: Validate version number
-        run: >-
-          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            if ! [[ "${{ steps.vars.outputs.tag }}" =~ "b" ]]; then
-            echo "Pre-release: Tag is missing beta suffix (${{ steps.vars.outputs.tag }})"
+        env:
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            if ! [[ "$TAG" =~ "b" ]]; then
+              echo "Pre-release: Tag is missing beta suffix ($TAG)"
               exit 1
             fi
           else
-            if [[ "${{ steps.vars.outputs.tag }}" =~ "b" ]]; then
-              echo "Release: Tag must not have a beta suffix (${{ steps.vars.outputs.tag }})"
+            if [[ "$TAG" =~ "b" ]]; then
+              echo "Release: Tag must not have a beta suffix ($TAG)"
               exit 1
             fi
           fi
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install build
@@ -39,22 +47,29 @@ jobs:
           pip install build tomli tomli-w
       - name: Set Python project version from tag
         shell: python
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
         run: |-
+          import os
+
           import tomli
           import tomli_w
 
           with open("pyproject.toml", "rb") as f:
             pyproject = tomli.load(f)
 
-          pyproject["project"]["version"] = "${{ steps.vars.outputs.tag }}"
+          pyproject["project"]["version"] = os.environ["TAG"]
 
           with open("pyproject.toml", "wb") as f:
             tomli_w.dump(pyproject, f)
       - name: Build python package
         run: >-
           python3 -m build
+      # TODO: switch to PyPI Trusted Publishing (OIDC). That drops this static
+      # token and gets us PEP 740 provenance attestations, which a static token
+      # cannot produce. Requires registering a trusted publisher on PyPI first.
       - name: Publish release to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.PYPI_TOKEN }} # zizmor: ignore[use-trusted-publishing]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,45 +9,60 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v7.0.1
-      - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          python-version: "3.11"
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip build setuptools
-          pip install . .[test]
+          python -m pip install --upgrade pip
+          pip install .[test]
       - name: Lint/test with pre-commit
         run: SKIP=no-commit-to-branch pre-commit run --all-files
 
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip build setuptools
+          python -m pip install --upgrade pip
           pip install .[test]
       - name: Pytest
         run: pytest --durations 10 --cov-report term-missing --cov=aiohue --cov-report=xml tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,12 @@ repos:
         types: [text]
         entry: scripts/run-in-env.sh trailing-whitespace-fixer
         stages: [pre-commit, pre-push, manual]
+      - id: zizmor
+        name: 🔒 Auditing GitHub Actions workflows with zizmor
+        language: system
+        files: ^\.github/workflows/
+        entry: scripts/run-in-env.sh zizmor
+        require_serial: true
       # TODO: enable mypy and solve the found issues
       # - id: mypy
       #   name: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ classifiers = [
   "Environment :: Console",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "aiohttp",
@@ -38,7 +40,14 @@ test = [
   "pytest-cov==7.1.0",
   "ruff==0.16.0",
   "safety==3.7.0",
+  "zizmor==1.28.0",
 ]
+
+[project.urls]
+Changelog = "https://github.com/home-assistant-libs/aiohue/releases"
+Homepage = "https://github.com/home-assistant-libs/aiohue"
+Issues = "https://github.com/home-assistant-libs/aiohue/issues"
+Source = "https://github.com/home-assistant-libs/aiohue"
 
 [tool.codespell]
 ignore-words-list = "dependees,"


### PR DESCRIPTION
Home Assistant's requirements check [flagged aiohue](https://github.com/home-assistant/core/pull/177631#issuecomment-5129602259) for not advertising a source repository URL on PyPI. That single gap also fails its source inspection, PR link and async-safety checks, since none of them can find the code to look at.

While in there, the lint and test jobs turned out to have `continue-on-error: true`, so a failing test suite still reported green.

- Add `[project.urls]` so PyPI links back to the repository
- Drop `continue-on-error` from the lint and test jobs
- Pin all actions to commit SHAs and give every workflow least-privilege `permissions`
- Fix the release drafter trigger, which still pointed at `master` and therefore never ran
- Run the tests on Python 3.13 and 3.14 as well
- Add cooldown, grouping and labels to the dependabot config
- Audit the workflows with [zizmor](https://docs.zizmor.sh) from pre-commit, to keep the pinning and permissions from drifting back

Publishing still uses the `PYPI_TOKEN` secret. Moving to trusted publishing would also get us PEP 740 provenance attestations, but it needs a trusted publisher registered on PyPI first, so it is left as a TODO in the workflow.